### PR TITLE
Add new calico 3.26.1-1 images with ipset v7.17

### DIFF
--- a/images/calico-cni/v3.26.1-1/Dockerfile
+++ b/images/calico-cni/v3.26.1-1/Dockerfile
@@ -1,0 +1,41 @@
+# https://github.com/projectcalico/calico/blob/v3.26.1/cni-plugin/Dockerfile.amd64
+
+ARG \
+  VERSION=3.26.1 \
+  HASH=6d0afbbd4bdfe4deb18d0ac30adb7165eb08b0114ec5a00d016f37a8caf88849
+
+FROM docker.io/calico/cni:v$VERSION as upstream
+
+FROM docker.io/library/golang:1.20.8-alpine3.18 as builder
+
+ARG VERSION HASH
+RUN wget https://github.com/projectcalico/calico/archive/refs/tags/v$VERSION.tar.gz \
+  && { echo "$HASH *v$VERSION.tar.gz" | sha256sum -c -; } \
+  && mkdir /go/calico && tar xf "v$VERSION.tar.gz" --strip-components=1 -C /go/calico \
+  && rm -- "v$VERSION.tar.gz"
+
+COPY --from=upstream /licenses/ /out/licenses/
+COPY --from=upstream /opt/cni/ /out/opt/cni/
+RUN set -e \
+  && apk add --no-cache binutils \
+  && rm /out/opt/cni/bin/install /out/opt/cni/bin/calico /out/opt/cni/bin/calico-ipam \
+  && strip /out/opt/cni/bin/*
+
+WORKDIR /go/calico
+RUN CGO_ENABLED=0 go build \
+  -v -buildvcs=false \
+  -o /out/opt/cni/bin/calico \
+  -ldflags "-s -w -X main.VERSION=v$VERSION" \
+  ./cni-plugin/cmd/calico
+
+RUN set -e \
+  && cd /out/opt/cni/bin \
+  && ln -s calico calico-ipam \
+  && ln -s calico install
+
+FROM scratch
+COPY --from=builder /out/ /
+
+ENV PATH=/opt/cni/bin
+WORKDIR /opt/cni/bin
+CMD ["/opt/cni/bin/install"]

--- a/images/calico-kube-controllers/v3.26.1-1/Dockerfile
+++ b/images/calico-kube-controllers/v3.26.1-1/Dockerfile
@@ -1,0 +1,34 @@
+# https://github.com/projectcalico/calico/blob/v3.26.1/kube-controllers/Dockerfile.amd64
+
+ARG \
+  VERSION=3.26.1 \
+  HASH=6d0afbbd4bdfe4deb18d0ac30adb7165eb08b0114ec5a00d016f37a8caf88849
+
+FROM docker.io/library/golang:1.20.8-alpine3.18 as builder
+
+ARG VERSION HASH
+RUN wget https://github.com/projectcalico/calico/archive/refs/tags/v$VERSION.tar.gz \
+  && { echo "$HASH *v$VERSION.tar.gz" | sha256sum -c -; } \
+  && mkdir /go/calico && tar xf "v$VERSION.tar.gz" --strip-components=1 -C /go/calico \
+  && rm -- "v$VERSION.tar.gz"
+
+WORKDIR /go/calico
+RUN mkdir -p /out/usr/bin \
+  && CGO_ENABLED=0 go build \
+    -v -buildvcs=false \
+    -ldflags "-s -w -X main.VERSION=v$VERSION" \
+    -o /out/usr/bin/kube-controllers \
+    ./kube-controllers/cmd/kube-controllers \
+  && CGO_ENABLED=0 go build \
+    -v -buildvcs=false \
+    -ldflags "-s -w -X main.VERSION=v$VERSION" \
+    -o /out/usr/bin/check-status \
+    ./kube-controllers/cmd/check-status
+
+RUN mkdir /out/licenses && cp -a kube-controllers/LICENSE /out/licenses/
+RUN mkdir /out/status && touch /out/status/status.json && chown 999 /out/status/status.json
+
+FROM scratch
+COPY --from=builder /out/ /
+USER 999
+ENTRYPOINT ["/usr/bin/kube-controllers"]

--- a/images/calico-node/v3.26.1-1/Dockerfile
+++ b/images/calico-node/v3.26.1-1/Dockerfile
@@ -1,0 +1,45 @@
+# https://github.com/projectcalico/calico/blob/v3.26.1/node/Dockerfile.amd64
+
+ARG \
+  VERSION=3.26.1 \
+  HASH=6d0afbbd4bdfe4deb18d0ac30adb7165eb08b0114ec5a00d016f37a8caf88849 \
+  IPSET_VERSION=7.17 \
+  IPSET_HASH=be49c9ff489dd6610cad6541e743c3384eac96e9f24707da7b3929d8f2ac64d8
+
+FROM docker.io/library/golang:1.20.8-alpine3.18 as builder
+
+ARG VERSION HASH
+RUN wget https://github.com/projectcalico/calico/archive/refs/tags/v$VERSION.tar.gz \
+  && { echo "$HASH *v$VERSION.tar.gz" | sha256sum -c -; } \
+  && mkdir /go/calico && tar xf "v$VERSION.tar.gz" --strip-components=1 -C /go/calico \
+  && rm -- "v$VERSION.tar.gz"
+
+WORKDIR /go/calico
+RUN CGO_ENABLED=0 go build -buildvcs=false -v -o calico-node -ldflags "-s -w -X main.VERSION=v$VERSION" ./node/cmd/calico-node
+
+FROM docker.io/library/alpine:3.18.3 as ipset
+RUN apk add --no-cache \
+  build-base pkgconf curl \
+  libmnl-dev libmnl-static
+
+ARG IPSET_VERSION IPSET_HASH
+RUN curl -sSLo ipset.tar.bz2 "http://ipset.netfilter.org/ipset-$IPSET_VERSION.tar.bz2" \
+  && { echo "$IPSET_HASH *ipset.tar.bz2" | sha256sum -c -; } \
+  && mkdir -p /src/ipset && tar xf "ipset.tar.bz2" --strip-components=1 -C /src/ipset \
+  && rm -- "ipset.tar.bz2"
+
+WORKDIR /src/ipset
+RUN printf '#!/usr/bin/env sh\nexec cc -static "$@"\n' >/src/cc-static && chmod +x /src/cc-static
+RUN CC=/src/cc-static CFLAGS=-static LDFLAGS=-static ./configure --enable-static --disable-shared --with-kmod=no
+RUN make && strip src/ipset
+RUN make install
+
+FROM docker.io/calico/node:v$VERSION as intermediate
+COPY --from=builder /go/calico/calico-node /usr/bin/calico-node
+COPY --from=ipset /usr/local/sbin/ipset /usr/sbin/ipset
+COPY --from=ipset /src/ipset/ChangeLog /usr/share/doc/ipset/ChangeLog
+
+FROM scratch
+COPY --from=intermediate / /
+ENV SVDIR=/etc/service/enabled
+CMD ["start_runit"]


### PR DESCRIPTION
The new ipset version is required for kernels >= 6.2, when the kube-proxy image is also using that version of ipset.

Also streamline the Dockerfiles and produce smaller images by stripping debug infos and stuffing everything into a single final layer.