### PR TITLE
Add envoy-distroless v1.24.12

### DIFF
--- a/images/envoy-distroless/v1.24.12/Dockerfile
+++ b/images/envoy-distroless/v1.24.12/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.io/envoyproxy/envoy-distroless:v1.24.12@sha256:64947105ceb0b3eed9b9c8452a0bbe04c208ddc51d38b1a77135ab025e659d8c
+
+# Just take the base image verbatim, as this doesn't have any fixable
+# vulnerabilities at the time of writing.


### PR DESCRIPTION
Fixes CVE-2023-44487 (already in v1.24.11).

https://github.com/envoyproxy/envoy/releases/tag/v1.24.11 https://github.com/envoyproxy/envoy/releases/tag/v1.24.12