### PR TITLE
Add kube-proxy v1.28.4 and v1.27.8

### DIFF
--- a/images/kube-proxy/v1.27.8/Dockerfile
+++ b/images/kube-proxy/v1.27.8/Dockerfile
@@ -1,0 +1,55 @@
+FROM docker.io/library/golang:1.20.11-alpine3.18 as binary
+
+RUN apk add --no-cache cmd:make cmd:bash cmd:rsync
+
+# https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#source-code
+ARG \
+  VERSION=1.27.8 \
+  HASH=119afe357398239dd00ac065a57327be75bd4f562a94ad800e472bd2068c58dadbd50970b6876e7cccaa66b4f34ccb2023c14173dbab0f44cfa41dfa6adafa37
+
+RUN wget https://dl.k8s.io/v${VERSION}/kubernetes-src.tar.gz && \
+  { echo "${HASH} *kubernetes-src.tar.gz" | sha512sum -c -; } && \
+  mkdir -p /go/kubernetes && \
+  tar xf kubernetes-src.tar.gz -C /go/kubernetes && \
+  rm kubernetes-src.tar.gz
+
+RUN make -C /go/kubernetes \
+  WHAT=cmd/kube-proxy \
+  FORCE_HOST_GO=y \
+  KUBE_STATIC_OVERRIDES=kube-proxy \
+  KUBE_VERBOSE=9
+
+FROM docker.io/library/debian:bullseye-slim as build
+
+COPY files/package-utils.sh /
+COPY files/stage-binaries-from-package.sh /
+COPY files/stage-binary-and-deps.sh /
+
+RUN mkdir -p /opt/stage && \
+    /stage-binaries-from-package.sh /opt/stage conntrack \
+    ebtables    \
+    ipset       \
+    iptables    \
+    kmod && \
+    /stage-binary-and-deps.sh /opt/stage /bin/dash \
+    /bin/cat \
+    /bin/chmod \
+    /bin/grep \
+    /bin/ln  \
+    /bin/rm \
+    /bin/sleep \
+    /usr/bin/wc && \
+    ln -sf /bin/dash /opt/stage/bin/sh
+
+RUN ls -la /opt/stage/usr/sbin
+
+FROM gcr.io/distroless/base
+
+COPY files/iptables-wrapper-installer.sh /
+COPY files/clean-distroless.sh /
+COPY --from=build /opt/stage /
+COPY --from=binary /go/kubernetes/_output/local/bin/linux/*/kube-proxy /usr/local/bin/kube-proxy
+
+RUN echo "" >  /usr/sbin/iptables && /iptables-wrapper-installer.sh --no-sanity-check && /clean-distroless.sh
+
+ENTRYPOINT ["/usr/local/bin/kube-proxy"]

--- a/images/kube-proxy/v1.27.8/README.md
+++ b/images/kube-proxy/v1.27.8/README.md
@@ -1,0 +1,5 @@
+# kube-proxy image
+
+Build process is mostly copied from the upstream:
+
+https://github.com/kubernetes/release/tree/master/images/build/distroless-iptables/distroless

--- a/images/kube-proxy/v1.27.8/files/clean-distroless.sh
+++ b/images/kube-proxy/v1.27.8/files/clean-distroless.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE: clean-distroless.sh
+
+REMOVE="/usr/share/base-files
+/usr/share/man
+/usr/lib/*-linux-gnu/gconv/
+/usr/bin/c_rehash
+/usr/bin/openssl
+/iptables-wrapper-installer.sh
+/clean-distroless.sh"
+
+IFS="
+"
+
+for item in ${REMOVE}; do
+    rm -rf "${item}"
+done

--- a/images/kube-proxy/v1.27.8/files/iptables-wrapper-installer.sh
+++ b/images/kube-proxy/v1.27.8/files/iptables-wrapper-installer.sh
@@ -1,0 +1,208 @@
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+#   iptables-wrapper-installer.sh [--no-sanity-check]
+#
+# Installs a wrapper iptables script in a container that will figure out
+# whether iptables-legacy or iptables-nft is in use on the host and then
+# replaces itself with the correct underlying iptables version.
+#
+# Unless "--no-sanity-check" is passed, it will first verify that the
+# container already contains a suitable version of iptables.
+
+# NOTE: This can only use POSIX /bin/sh features; the build container
+# might not contain bash.
+
+set -eu
+
+# Find iptables binary location
+if [ -d /usr/sbin -a -e /usr/sbin/iptables ]; then
+    sbin="/usr/sbin"
+elif [ -d /sbin -a -e /sbin/iptables ]; then
+    sbin="/sbin"
+else
+    echo "ERROR: iptables is not present in either /usr/sbin or /sbin" 1>&2
+    exit 1
+fi
+
+# Determine how the system selects between iptables-legacy and iptables-nft
+if [ -x /usr/sbin/alternatives ]; then
+    # Fedora/SUSE style alternatives
+    altstyle="fedora"
+elif [ -x /usr/sbin/update-alternatives ]; then
+    # Debian style alternatives
+    altstyle="debian"
+else
+    # No alternatives system
+    altstyle="none"
+fi
+
+if [ "${1:-}" != "--no-sanity-check" ]; then
+    # Ensure dependencies are installed
+    if ! version=$("${sbin}/iptables-nft" --version 2> /dev/null); then
+        echo "ERROR: iptables-nft is not installed" 1>&2
+        exit 1
+    fi
+    if ! "${sbin}/iptables-legacy" --version > /dev/null 2>&1; then
+        echo "ERROR: iptables-legacy is not installed" 1>&2
+        exit 1
+    fi
+
+    case "${version}" in
+    *v1.8.[0123]\ *)
+        echo "ERROR: iptables 1.8.0 - 1.8.3 have compatibility bugs." 1>&2
+        echo "       Upgrade to 1.8.4 or newer." 1>&2
+        exit 1
+        ;;
+    *)
+        # 1.8.4+ are OK
+        ;;
+    esac
+fi
+
+# Start creating the wrapper...
+rm -f "${sbin}/iptables-wrapper"
+cat > "${sbin}/iptables-wrapper" <<EOF
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This can only use POSIX /bin/sh features; the container image
+# might not contain bash.
+
+set -eu
+
+# In kubernetes 1.17 and later, kubelet will have created at least
+# one chain in the "mangle" table (either "KUBE-IPTABLES-HINT" or
+# "KUBE-KUBELET-CANARY"), so check that first, against
+# iptables-nft, because we can check that more efficiently and
+# it's more common these days.
+nft_kubelet_rules=\$( (iptables-nft-save -t mangle || true; ip6tables-nft-save -t mangle || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+if [ "\${nft_kubelet_rules}" -ne 0 ]; then
+    mode=nft
+else
+    # Check for kubernetes 1.17-or-later with iptables-legacy. We
+    # can't pass "-t mangle" to iptables-legacy-save because it would
+    # cause the kernel to create that table if it didn't already
+    # exist, which we don't want. So we have to grab all the rules
+    legacy_kubelet_rules=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+    if [ "\${legacy_kubelet_rules}" -ne 0 ]; then
+        mode=legacy
+    else
+        # With older kubernetes releases there may not be any _specific_
+        # rules we can look for, but we assume that some non-containerized process
+        # (possibly kubelet) will have created _some_ iptables rules.
+        num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+        num_nft_lines=\$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+        if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
+            mode=legacy
+        else
+            mode=nft
+        fi
+    fi
+fi
+
+EOF
+
+# Write out the appropriate alternatives-selection commands
+case "${altstyle}" in
+    fedora)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    debian)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    *)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${sbin}/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "${sbin}/\${cmd}"
+done 2>/dev/null || failed=1
+EOF
+    ;;
+esac
+
+# Write out the post-alternatives-selection error checking and final wrap-up
+cat >> "${sbin}/iptables-wrapper" <<EOF
+if [ "\${failed:-0}" = 1 ]; then
+    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    # fake it, though this will probably also fail if they aren't root
+    exec "${sbin}/xtables-\${mode}-multi" "\$0" "\$@"
+fi
+
+# Now re-exec the original command with the newly-selected alternative
+exec "\$0" "\$@"
+EOF
+chmod +x "${sbin}/iptables-wrapper"
+
+# Now back in the installer script, point the iptables binaries at our
+# wrapper
+case "${altstyle}" in
+    fedora)
+	alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+	;;
+
+    debian)
+	update-alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+	update-alternatives \
+            --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+	;;
+
+    *)
+	for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+            rm -f "${sbin}/${cmd}"
+            ln -s "${sbin}/iptables-wrapper" "${sbin}/${cmd}"
+	done
+	;;
+esac
+
+# Cleanup
+rm -f "$0"

--- a/images/kube-proxy/v1.27.8/files/package-utils.sh
+++ b/images/kube-proxy/v1.27.8/files/package-utils.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# file_to_package identifies the debian package that provided the file $1
+file_to_package() {
+    # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
+    # where $file-path belongs to $package
+    # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
+    dpkg-query --search "$(realpath "${1}")" | cut -d':' -f1
+}
+
+# package_to_copyright gives the path to the copyright file for the package $1
+package_to_copyright() {
+    echo "/usr/share/doc/${1}/copyright"
+}
+
+# stage_file stages the filepath $1 to $2, following symlinks
+# and staging copyrights
+stage_file() {
+    cp -a --parents "${1}" "${2}"
+    # recursively follow symlinks
+    if [[ -L "${1}" ]]; then
+        stage_file "$(cd "$(dirname "${1}")" || exit; realpath -s "$(readlink "${1}")")" "${2}"
+    fi
+    # get the package so we can stage package metadata as well
+    package="$(file_to_package "${1}")"
+    # stage the copyright for the file
+    cp -a --parents "$(package_to_copyright "${package}")" "${2}"
+    # stage the package status mimicking bazel
+    # https://github.com/bazelbuild/rules_docker/commit/f5432b813e0a11491cf2bf83ff1a923706b36420
+    # instead of parsing the control file, we can just get the actual package status with dpkg
+    dpkg -s "${package}" > "${2}/var/lib/dpkg/status.d/${package}"
+}

--- a/images/kube-proxy/v1.27.8/files/stage-binaries-from-package.sh
+++ b/images/kube-proxy/v1.27.8/files/stage-binaries-from-package.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE: stage-binaries-from-package.sh /opt/stage package1 package2
+#
+# Stages all the packages and its dependencies (+ libraries and copyrights) to $1
+#
+# This is intended to be used in a multi-stage docker build with a distroless/base
+# or distroless/cc image.
+set -e
+
+. package-utils.sh
+
+stage_file_list() {
+    IFS="
+    "
+    REQUIRED_FILES="$(dpkg -L "${1}" | grep -vE '(/\.|/s?bin/|/usr/share/(man|doc|.*-completion))' | sed 's/\n/ /g')"
+    for file in $REQUIRED_FILES; do
+        if [ -f "$file" ]; then
+            stage_file "${file}" "${STAGE_DIR}"
+        fi
+    done
+
+    BIN_LIST="$(dpkg -L "${1}" | grep -E '/s?bin/' |sed 's/\n/ /g')"
+    for binary in $BIN_LIST; do
+        /stage-binary-and-deps.sh "${2}" "${binary}"
+    done
+}
+
+get_dependent_packages() {
+    apt-cache depends "${1}" |grep Depends|awk -F '.*Depends:[[:space:]]?' '{print $2}'
+}
+
+main() {
+    STAGE_DIR="${1}/"
+    mkdir -p "${STAGE_DIR}"/var/lib/dpkg/status.d/
+    apt -y update
+    shift
+    while (( "$#" )); do        # While there are arguments still to be shifted
+        PACKAGE="${1}"
+        apt -y install "${PACKAGE}"
+        stage_file_list "${PACKAGE}" "$STAGE_DIR"
+        while IFS= read -r c_dep; do
+            stage_file_list "${c_dep}" "${STAGE_DIR}"
+        done < <(get_dependent_packages "${PACKAGE}")
+        shift
+    done
+}
+
+main "$@"

--- a/images/kube-proxy/v1.27.8/files/stage-binary-and-deps.sh
+++ b/images/kube-proxy/v1.27.8/files/stage-binary-and-deps.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE: stage-binary-and-deps.sh haproxy /opt/stage
+#
+# Stages $1 and its dependencies + their copyright files to $2
+#
+# This is intended to be used in a multi-stage docker build with a distroless/base
+# or distroless/cc image.
+# This script was originally created by KinD maintainers and can be found at:
+#   https://github.com/kubernetes-sigs/kind/blob/v0.14.0/images/haproxy/stage-binary-and-deps.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+. package-utils.sh
+
+# binary_to_libraries identifies the library files needed by the binary $1 with ldd
+binary_to_libraries() {
+    # see: https://man7.org/linux/man-pages/man1/ldd.1.html
+    ldd "${1}" \
+    `# strip the leading '${name} => ' if any so only '/lib-foo.so (0xf00)' remains` \
+    | sed -E 's#.* => /#/#' \
+    `# we want only the path remaining, not the (0x${LOCATION})` \
+    | awk '{print $1}' \
+    `# linux-vdso.so.1 is a special virtual shared object from the kernel` \
+    `# see: http://man7.org/linux/man-pages/man7/vdso.7.html` \
+    | grep -v 'linux-vdso.so.1'
+}
+
+# main script logic
+main(){
+    local STAGE_DIR="${1}/"
+    shift
+    while (( "$#" )); do
+        BINARY="${1}"
+        # locate the path to the binary
+        local binary_path
+        binary_path="$(which "${BINARY}")"
+
+        # ensure package metadata dir
+        mkdir -p "${STAGE_DIR}"/var/lib/dpkg/status.d/
+
+        # stage the binary itself
+        stage_file "${binary_path}" "${STAGE_DIR}"
+
+        # stage the dependencies of the binary
+        while IFS= read -r c_dep; do
+            stage_file "${c_dep}" "${STAGE_DIR}"
+        done < <(binary_to_libraries "${binary_path}")
+        shift
+    done
+}
+
+main "$@"

--- a/images/kube-proxy/v1.28.4/Dockerfile
+++ b/images/kube-proxy/v1.28.4/Dockerfile
@@ -1,0 +1,67 @@
+FROM docker.io/library/golang:1.20.11-alpine3.18 as binary
+
+RUN apk add --no-cache cmd:make cmd:bash cmd:rsync
+
+# https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#source-code
+ARG \
+  VERSION=1.28.4 \
+  HASH=70b929f5ab11b0bb14d0e7870a2f4e3b4b1c5d52016cec4560198a339fe3363c6e9de0ebc50b643ba12d569bd527737141c36d8abccb559596e772624a8219cb
+
+RUN wget https://dl.k8s.io/v${VERSION}/kubernetes-src.tar.gz && \
+  { echo "${HASH} *kubernetes-src.tar.gz" | sha512sum -c -; } && \
+  mkdir -p /go/kubernetes && \
+  tar xf kubernetes-src.tar.gz -C /go/kubernetes && \
+  rm kubernetes-src.tar.gz
+
+RUN make -C /go/kubernetes \
+  WHAT=cmd/kube-proxy \
+  FORCE_HOST_GO=y \
+  KUBE_STATIC_OVERRIDES=kube-proxy \
+  KUBE_VERBOSE=9
+
+
+# https://github.com/kubernetes/release/blob/2fc3173c599fcd6b1835df46ce56398046616e8c/images/build/distroless-iptables/distroless/Dockerfile#L18-L69
+FROM docker.io/library/debian:bookworm-slim as build
+
+COPY files/stage-binary-and-deps.sh /
+COPY files/stage-binaries-from-package.sh /
+COPY files/package-utils.sh /
+
+
+RUN apt-get -y update && \
+    apt-get -y dist-upgrade && \
+    apt-get -y install bash curl && \
+    mkdir -p /opt/stage && \
+    /stage-binaries-from-package.sh /opt/stage conntrack \
+    ebtables    \
+    ipset       \
+    iptables    \
+    kmod        && \
+    `# below binaries and dash are used by iptables-wrapper-installer.sh` \
+    /stage-binary-and-deps.sh /opt/stage /bin/dash \
+    /bin/cat \
+    /bin/chmod \
+    /bin/grep \
+    /bin/ln  \
+    /bin/rm \
+    /bin/sleep \
+    /usr/bin/wc && \
+    ln -sf /bin/dash /opt/stage/bin/sh
+
+# We need to use distroless:base here as tzdata, glibc and some other base packages
+# are required
+FROM gcr.io/distroless/base-debian12 as intermediate
+
+COPY files/clean-distroless.sh /clean-distroless.sh
+COPY files/iptables-wrapper-installer.sh /iptables-wrapper-installer.sh
+COPY --from=build /opt/stage /
+COPY --from=binary /go/kubernetes/_output/local/bin/linux/*/kube-proxy /usr/local/bin/kube-proxy
+# iptables-wrapper-installer needs to know that iptables exists before doing all its magic
+RUN echo "" >  /usr/sbin/iptables && \
+    /iptables-wrapper-installer.sh && \
+    /clean-distroless.sh
+
+FROM scratch
+COPY --from=intermediate / /
+
+ENTRYPOINT ["/usr/local/bin/kube-proxy"]

--- a/images/kube-proxy/v1.28.4/README.md
+++ b/images/kube-proxy/v1.28.4/README.md
@@ -1,0 +1,5 @@
+# kube-proxy image
+
+Build process is mostly copied from the upstream:
+
+https://github.com/kubernetes/release/tree/master/images/build/distroless-iptables/distroless

--- a/images/kube-proxy/v1.28.4/files/clean-distroless.sh
+++ b/images/kube-proxy/v1.28.4/files/clean-distroless.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE: clean-distroless.sh
+
+REMOVE="/usr/share/base-files
+/usr/share/man
+/usr/lib/*-linux-gnu/gconv/
+/usr/bin/c_rehash
+/usr/bin/openssl
+/iptables-wrapper-installer.sh
+/clean-distroless.sh"
+
+IFS="
+"
+
+for item in ${REMOVE}; do
+    rm -rf "${item}"
+done

--- a/images/kube-proxy/v1.28.4/files/iptables-wrapper-installer.sh
+++ b/images/kube-proxy/v1.28.4/files/iptables-wrapper-installer.sh
@@ -1,0 +1,212 @@
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+#   iptables-wrapper-installer.sh [--no-sanity-check]
+#
+# Installs a wrapper iptables script in a container that will figure out
+# whether iptables-legacy or iptables-nft is in use on the host and then
+# replaces itself with the correct underlying iptables version.
+#
+# Unless "--no-sanity-check" is passed, it will first verify that the
+# container already contains a suitable version of iptables.
+
+# NOTE: This can only use POSIX /bin/sh features; the build container
+# might not contain bash.
+
+set -eu
+
+# Find iptables binary location
+if [ -d /usr/sbin -a -e /usr/sbin/iptables ]; then
+    sbin="/usr/sbin"
+elif [ -d /sbin -a -e /sbin/iptables ]; then
+    sbin="/sbin"
+else
+    echo "ERROR: iptables is not present in either /usr/sbin or /sbin" 1>&2
+    exit 1
+fi
+
+# Determine how the system selects between iptables-legacy and iptables-nft
+if [ -x /usr/sbin/alternatives ]; then
+    # Fedora/SUSE style alternatives
+    altstyle="fedora"
+elif [ -x /usr/sbin/update-alternatives ]; then
+    # Debian style alternatives
+    altstyle="debian"
+else
+    # No alternatives system
+    altstyle="none"
+fi
+
+if [ "${1:-}" != "--no-sanity-check" ]; then
+    # Ensure dependencies are installed
+    # NOTE(k0s): iptables-nft will fail under QEMU on ARMv7 with the below error
+    # message, hence use iptables-legacy for the version check
+    if ! version=$("${sbin}/iptables-nft" --version 2>&1); then
+        if [ "$version" != "iptables: Failed to initialize nft: Protocol not supported" ]; then
+            echo "ERROR: iptables-nft is not installed" 1>&2
+            exit 1
+        fi
+    fi
+    if ! version=$("${sbin}/iptables-legacy" --version 2> /dev/null); then
+        echo "ERROR: iptables-legacy is not installed" 1>&2
+        exit 1
+    fi
+
+    case "${version}" in
+    *v1.8.[0123]\ *)
+        echo "ERROR: iptables 1.8.0 - 1.8.3 have compatibility bugs." 1>&2
+        echo "       Upgrade to 1.8.4 or newer." 1>&2
+        exit 1
+        ;;
+    *)
+        # 1.8.4+ are OK
+        ;;
+    esac
+fi
+
+# Start creating the wrapper...
+rm -f "${sbin}/iptables-wrapper"
+cat > "${sbin}/iptables-wrapper" <<EOF
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This can only use POSIX /bin/sh features; the container image
+# might not contain bash.
+
+set -eu
+
+# In kubernetes 1.17 and later, kubelet will have created at least
+# one chain in the "mangle" table (either "KUBE-IPTABLES-HINT" or
+# "KUBE-KUBELET-CANARY"), so check that first, against
+# iptables-nft, because we can check that more efficiently and
+# it's more common these days.
+nft_kubelet_rules=\$( (iptables-nft-save -t mangle || true; ip6tables-nft-save -t mangle || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+if [ "\${nft_kubelet_rules}" -ne 0 ]; then
+    mode=nft
+else
+    # Check for kubernetes 1.17-or-later with iptables-legacy. We
+    # can't pass "-t mangle" to iptables-legacy-save because it would
+    # cause the kernel to create that table if it didn't already
+    # exist, which we don't want. So we have to grab all the rules
+    legacy_kubelet_rules=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+    if [ "\${legacy_kubelet_rules}" -ne 0 ]; then
+        mode=legacy
+    else
+        # With older kubernetes releases there may not be any _specific_
+        # rules we can look for, but we assume that some non-containerized process
+        # (possibly kubelet) will have created _some_ iptables rules.
+        num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+        num_nft_lines=\$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+        if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
+            mode=legacy
+        else
+            mode=nft
+        fi
+    fi
+fi
+
+EOF
+
+# Write out the appropriate alternatives-selection commands
+case "${altstyle}" in
+    fedora)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    debian)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    *)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${sbin}/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "${sbin}/\${cmd}"
+done 2>/dev/null || failed=1
+EOF
+    ;;
+esac
+
+# Write out the post-alternatives-selection error checking and final wrap-up
+cat >> "${sbin}/iptables-wrapper" <<EOF
+if [ "\${failed:-0}" = 1 ]; then
+    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    # fake it, though this will probably also fail if they aren't root
+    exec "${sbin}/xtables-\${mode}-multi" "\$0" "\$@"
+fi
+
+# Now re-exec the original command with the newly-selected alternative
+exec "\$0" "\$@"
+EOF
+chmod +x "${sbin}/iptables-wrapper"
+
+# Now back in the installer script, point the iptables binaries at our
+# wrapper
+case "${altstyle}" in
+    fedora)
+	alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+	;;
+
+    debian)
+	update-alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+	update-alternatives \
+            --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+	;;
+
+    *)
+	for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+            rm -f "${sbin}/${cmd}"
+            ln -s "${sbin}/iptables-wrapper" "${sbin}/${cmd}"
+	done
+	;;
+esac
+
+# Cleanup
+rm -f "$0"

--- a/images/kube-proxy/v1.28.4/files/package-utils.sh
+++ b/images/kube-proxy/v1.28.4/files/package-utils.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# file_to_package identifies the debian package that provided the file $1
+file_to_package() {
+    # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
+    # where $file-path belongs to $package
+    # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
+    (dpkg-query --search "$(realpath "${1}")" || true) | cut -d':' -f1
+}
+
+# package_to_copyright gives the path to the copyright file for the package $1
+package_to_copyright() {
+    echo "/usr/share/doc/${1}/copyright"
+}
+
+# stage_file stages the filepath $1 to $2, following symlinks
+# and staging copyrights
+stage_file() {
+    # /lib is a symlink to /usr/lib in debian 12, means we just stick to
+    # /usr/lib for all libraries to avoid separating symlinks with the actual binaries
+    from="${1}"
+    if [[ $from = /lib/*  ]]; then
+        from="/usr$from"
+    fi
+    cp -a --parents "${from}" "${2}"
+    # recursively follow symlinks
+    if [[ -L "${from}" ]]; then
+        stage_file "$(cd "$(dirname "${from}")" || exit; realpath -s "$(readlink "${from}")")" "${2}"
+    fi
+    # get the package so we can stage package metadata as well
+    package="$(file_to_package "${from}")"
+
+    # files like /usr/lib/x86_64-linux-gnu/libc.so.6 will return no package
+    if [[ "$package" != "" ]]; then
+        # stage the copyright for the file
+        cp -a --parents "$(package_to_copyright "${package}")" "${2}"
+        # stage the package status mimicking bazel
+        # https://github.com/bazelbuild/rules_docker/commit/f5432b813e0a11491cf2bf83ff1a923706b36420
+        # instead of parsing the control file, we can just get the actual package status with dpkg
+        dpkg -s "${package}" > "${2}/var/lib/dpkg/status.d/${package}"
+    fi
+}

--- a/images/kube-proxy/v1.28.4/files/stage-binaries-from-package.sh
+++ b/images/kube-proxy/v1.28.4/files/stage-binaries-from-package.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE: stage-binaries-from-package.sh /opt/stage package1 package2
+#
+# Stages all the packages and its dependencies (+ libraries and copyrights) to $1
+#
+# This is intended to be used in a multi-stage docker build with a distroless/base
+# or distroless/cc image.
+set -e
+
+. package-utils.sh
+
+stage_file_list() {
+    IFS="
+    "
+    REQUIRED_FILES="$(dpkg -L "${1}" | grep -vE '(/\.|/s?bin/|/usr/share/(man|doc|.*-completion))' | sed 's/\n/ /g')"
+    for file in $REQUIRED_FILES; do 
+        if [ -f "$file" ]; then
+            stage_file "${file}" "${STAGE_DIR}"
+        fi
+    done
+
+    BIN_LIST="$(dpkg -L "${1}" | grep -E '/s?bin/' |sed 's/\n/ /g')"
+    for binary in $BIN_LIST; do
+        /stage-binary-and-deps.sh "${2}" "${binary}"
+    done
+}
+
+get_dependent_packages() {
+    apt-cache depends "${1}" |grep Depends|awk -F '.*Depends:[[:space:]]?' '{print $2}'
+}
+
+main() {
+    STAGE_DIR="${1}/"
+    mkdir -p "${STAGE_DIR}"/var/lib/dpkg/status.d/
+    apt-get -y update
+    shift
+    while (( "$#" )); do        # While there are arguments still to be shifted
+        PACKAGE="${1}"
+        apt-get -y install "${PACKAGE}"
+        stage_file_list "${PACKAGE}" "$STAGE_DIR"
+        while IFS= read -r c_dep; do
+            stage_file_list "${c_dep}" "${STAGE_DIR}"
+        done < <(get_dependent_packages "${PACKAGE}")
+        shift
+    done
+}
+
+main "$@"

--- a/images/kube-proxy/v1.28.4/files/stage-binary-and-deps.sh
+++ b/images/kube-proxy/v1.28.4/files/stage-binary-and-deps.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE: stage-binary-and-deps.sh haproxy /opt/stage
+#
+# Stages $1 and its dependencies + their copyright files to $2
+#
+# This is intended to be used in a multi-stage docker build with a distroless/base
+# or distroless/cc image.
+# This script was originally created by KinD maintainers and can be found at:
+#   https://github.com/kubernetes-sigs/kind/blob/v0.14.0/images/haproxy/stage-binary-and-deps.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+. package-utils.sh
+
+# binary_to_libraries identifies the library files needed by the binary $1 with ldd
+binary_to_libraries() {
+    # see: https://man7.org/linux/man-pages/man1/ldd.1.html
+    ldd "${1}" \
+    `# strip the leading '${name} => ' if any so only '/lib-foo.so (0xf00)' remains` \
+    | sed -E 's#.* => /#/#' \
+    `# we want only the path remaining, not the (0x${LOCATION})` \
+    | awk '{print $1}' \
+    `# linux-vdso.so.1 is a special virtual shared object from the kernel` \
+    `# see: http://man7.org/linux/man-pages/man7/vdso.7.html` \
+    | grep -v 'linux-vdso.so.1'
+}
+
+# main script logic
+main(){
+    local STAGE_DIR="${1}/"
+    shift
+    while (( "$#" )); do
+        BINARY="${1}"
+        # locate the path to the binary
+        local binary_path
+        binary_path="$(which "${BINARY}")"
+    
+        # ensure package metadata dir
+        mkdir -p "${STAGE_DIR}"/var/lib/dpkg/status.d/
+    
+        # stage the binary itself
+        stage_file "${binary_path}" "${STAGE_DIR}"
+    
+        # stage the dependencies of the binary
+        while IFS= read -r c_dep; do
+            stage_file "${c_dep}" "${STAGE_DIR}"
+        done < <(binary_to_libraries "${binary_path}")
+        shift
+    done
+}
+
+main "$@"


### PR DESCRIPTION
The Go bump fixes CVE-2023-45283 and CVE-2023-45284. The Kubernetes bump fixes CVE-2023-5528.