### PR TITLE
Bump envoy to v1.29.1

### DIFF
--- a/images/envoy-distroless/v1.29.1/Dockerfile
+++ b/images/envoy-distroless/v1.29.1/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.29.0@sha256:ac2ddb6a48d5325c05eda97834cf84e0889dc1ba2eddb1c0bd297ac22cfbbff3 as binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.29.1@sha256:76dcbc0509d51001da1c94937b4498bd30ae6eb074d98863336c522311b19fa4 as binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:684dee415923cb150793530f7997c96b3cef006c868738a2728597773cf27359
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:1a6f64f3fed75597fda0fa9cf8e60c3f6b029dedcef57071a2f42975a1b2bf8a
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml


### PR DESCRIPTION
Fixes CVE-2024-23324, CVE-2024-23325, CVE-2024-23322, CVE-2024-23323 and CVE-2024-23327.