### PR TITLE
Add notes about false-positive vulnerabilities (don't merge)

### DIFF
--- a/images/kube-proxy/v1.27.12/README.md
+++ b/images/kube-proxy/v1.27.12/README.md
@@ -3,3 +3,43 @@
 Build process is mostly copied from the upstream:
 
 https://github.com/kubernetes/release/tree/master/images/build/distroless-iptables/distroless
+
+## False positive security vulnerabilities
+
+The following CVEs are flagged by trivy and do not affect the `kube-proxy`
+binary:
+
+* [CVE-2023-2253]  
+  <https://github.com/kubernetes/kubernetes/pull/118036>  
+  > k/k doesn't use much code from docker/distribution so this doesn't change
+  > anything that's actually relevant, [...]
+
+* [CVE-2023-45142]  
+  <https://github.com/kubernetes/kubernetes/pull/121559#issuecomment-1782870871>  
+  > [...] kubernetes is NOT affected and we will not accept this cherry pick as
+  > it really does not do anything w.r.t security.
+
+* [CVE-2023-47108]  
+  <https://github.com/kubernetes/kubernetes/pull/121842>  
+  > This DOES NOT impact kubernetes, as we use OpenTelemetry only for tracing,
+  > and not for metrics. `go.opentelemetry.io/otel/sdk/metric` is not a
+  > dependency of this project.
+
+* [CVE-2023-48795]  
+  <https://github.com/kubernetes/kubernetes/pull/122424>  
+  > kubeadm preflight check at first glance seem to use some of the code, but
+  > kubeadm does not use SSH as a client AFAICT [...] None of the other k8s
+  > components act as a SSH server. API server did act as a client way back in
+  > time and that code was removed in 2021.
+
+* [CVE-2024-21626]  
+  <https://github.com/kubernetes/kubernetes/pull/123060>  
+  > Kubernetes uses `runc` for some aspects of kubelet, however we are NOT
+  > affected directly by the CVE-2024-21626 mentioned in the release notes for
+  > v1.1.12 directly (You do NOT need a new version of `kubelet`!).
+
+[CVE-2023-2253]:  https://avd.aquasec.com/nvd/cve-2023-2253
+[CVE-2023-45142]: https://avd.aquasec.com/nvd/cve-2023-45142
+[CVE-2023-47108]: https://avd.aquasec.com/nvd/cve-2023-47108
+[CVE-2023-48795]: https://avd.aquasec.com/nvd/cve-2023-48795
+[CVE-2024-21626]: https://avd.aquasec.com/nvd/cve-2024-21626

--- a/images/kube-proxy/v1.28.8/README.md
+++ b/images/kube-proxy/v1.28.8/README.md
@@ -3,3 +3,43 @@
 Build process is mostly copied from the upstream:
 
 https://github.com/kubernetes/release/tree/master/images/build/distroless-iptables/distroless
+
+## False positive security vulnerabilities
+
+The following CVEs are flagged by trivy and do not affect the `kube-proxy`
+binary:
+
+* [CVE-2023-2253]  
+  <https://github.com/kubernetes/kubernetes/pull/118036>  
+  > k/k doesn't use much code from docker/distribution so this doesn't change
+  > anything that's actually relevant, [...]
+
+* [CVE-2023-45142]  
+  <https://github.com/kubernetes/kubernetes/pull/121559#issuecomment-1782870871>  
+  > [...] kubernetes is NOT affected and we will not accept this cherry pick as
+  > it really does not do anything w.r.t security.
+
+* [CVE-2023-47108]  
+  <https://github.com/kubernetes/kubernetes/pull/121842>  
+  > This DOES NOT impact kubernetes, as we use OpenTelemetry only for tracing,
+  > and not for metrics. `go.opentelemetry.io/otel/sdk/metric` is not a
+  > dependency of this project.
+
+* [CVE-2023-48795]  
+  <https://github.com/kubernetes/kubernetes/pull/122424>  
+  > kubeadm preflight check at first glance seem to use some of the code, but
+  > kubeadm does not use SSH as a client AFAICT [...] None of the other k8s
+  > components act as a SSH server. API server did act as a client way back in
+  > time and that code was removed in 2021.
+
+* [CVE-2024-21626]  
+  <https://github.com/kubernetes/kubernetes/pull/123060>  
+  > Kubernetes uses `runc` for some aspects of kubelet, however we are NOT
+  > affected directly by the CVE-2024-21626 mentioned in the release notes for
+  > v1.1.12 directly (You do NOT need a new version of `kubelet`!).
+
+[CVE-2023-2253]:  https://avd.aquasec.com/nvd/cve-2023-2253
+[CVE-2023-45142]: https://avd.aquasec.com/nvd/cve-2023-45142
+[CVE-2023-47108]: https://avd.aquasec.com/nvd/cve-2023-47108
+[CVE-2023-48795]: https://avd.aquasec.com/nvd/cve-2023-48795
+[CVE-2024-21626]: https://avd.aquasec.com/nvd/cve-2024-21626

--- a/images/kube-proxy/v1.29.3/README.md
+++ b/images/kube-proxy/v1.29.3/README.md
@@ -4,10 +4,42 @@ This is k0s's [kube-proxy] image. It's an Alpine variant of what can be found in
 the upstream [iptables-distroless] image, plus the `kube-proxy` executable. It
 uses the new binary `iptables-wrapper`, so that it doesn't need a shell anymore.
 
+## False positive security vulnerabilities
+
+The following CVEs are flagged by trivy and do not affect the `kube-proxy`
+binary:
+
+* [CVE-2023-2253]  
+  <https://github.com/kubernetes/kubernetes/pull/118036>  
+  > k/k doesn't use much code from docker/distribution so this doesn't change
+  > anything that's actually relevant, [...]
+
+* [CVE-2023-45142]  
+  <https://github.com/kubernetes/kubernetes/pull/121559#issuecomment-1782870871>  
+  > [...] kubernetes is NOT affected and we will not accept this cherry pick as
+  > it really does not do anything w.r.t security.
+
+* [CVE-2023-47108]  
+  <https://github.com/kubernetes/kubernetes/pull/121842>  
+  > This DOES NOT impact kubernetes, as we use OpenTelemetry only for tracing,
+  > and not for metrics. `go.opentelemetry.io/otel/sdk/metric` is not a
+  > dependency of this project.
+
+* [CVE-2023-48795]  
+  <https://github.com/kubernetes/kubernetes/pull/122424>  
+  > kubeadm preflight check at first glance seem to use some of the code, but
+  > kubeadm does not use SSH as a client AFAICT [...] None of the other k8s
+  > components act as a SSH server. API server did act as a client way back in
+  > time and that code was removed in 2021.
+
+* [CVE-2024-21626]  
+  <https://github.com/kubernetes/kubernetes/pull/123060>  
+  > Kubernetes uses `runc` for some aspects of kubelet, however we are NOT
+  > affected directly by the CVE-2024-21626 mentioned in the release notes for
+  > v1.1.12 directly (You do NOT need a new version of `kubelet`!).
+
 Notes:
 
-* Trivy flags [CVE-2023-47108] on the `kube-proxy` binary. This is tracked
-  upstream in [k/k#121842].
 * Alpine's `kmod` package depends on `/bin/sh` for its trigger scripts run at
   package installation. Hence `apk` refuses to purge `busybox`. Have a little
   nasty hack in place that fiddles with Alpine's package database to remove that
@@ -23,7 +55,10 @@ Notes:
 
 [kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/
 [iptables-distroless]: https://github.com/kubernetes/release/tree/master/images/build/distroless-iptables/distroless
+[CVE-2023-2253]:  https://avd.aquasec.com/nvd/cve-2023-2253
+[CVE-2023-45142]: https://avd.aquasec.com/nvd/cve-2023-45142
 [CVE-2023-47108]: https://avd.aquasec.com/nvd/cve-2023-47108
-[k/k#121842]: https://github.com/kubernetes/kubernetes/pull/121842
+[CVE-2023-48795]: https://avd.aquasec.com/nvd/cve-2023-48795
+[CVE-2024-21626]: https://avd.aquasec.com/nvd/cve-2024-21626
 [nftables backend]: https://github.com/kubernetes/enhancements/issues/3866
 [KEP-3866]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/3866-nftables-proxy/README.md


### PR DESCRIPTION
For reference. Don't merge this, as it would currently retrigger/republish the already published images, as the workflows as they are now will trigger a build for any change in the image folders, even if it's just the readme files.