### PR TITLE
Bump envoy to v1.29.3

### DIFF
--- a/images/envoy-distroless/v1.29.3/Dockerfile
+++ b/images/envoy-distroless/v1.29.3/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.29.2@sha256:9f0101d0429a123aeca1369b860559517e0f889b01c1795bc927c9befd60b2b5 as binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.29.3@sha256:3c8e339269db9fa842ad5b9942700a244197052f7c8b8adced36390f2b3a8860 as binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:3d46a42c741d469811b95d0b6ec9d10c15ebb1be7c5eaa989d429d91b066d78c
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:1c99fceaba16f833d6eb030c07d6304bce68f18350e1a0c69a85b8781afc00d9
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml


### PR DESCRIPTION
https://www.envoyproxy.io/docs/envoy/v1.29.3/version_history/v1.29/v1.29.3

Fixes CVE-2024-30255.