### PR TITLE
Add kube-router v1.6.1

### DIFF
--- a/images/kube-router/v1.6.1-iptables1.8.9-0/Dockerfile
+++ b/images/kube-router/v1.6.1-iptables1.8.9-0/Dockerfile
@@ -1,11 +1,11 @@
-ARG KUBE_ROUTER_VERSION=v1.6.0
+ARG KUBE_ROUTER_VERSION=v1.6.1
 FROM docker.io/cloudnativelabs/kube-router:${KUBE_ROUTER_VERSION} as binaries
 
-FROM docker.io/library/golang:1.21.5-alpine3.18 as build
+FROM docker.io/library/golang:1.21.9-alpine3.18 as build
 ARG KUBE_ROUTER_VERSION
 RUN apk add --no-cache git
 
-RUN git clone -b v3.21.0 https://github.com/osrg/gobgp.git /gobgp
+RUN git -c advice.detachedHead=false clone --depth 1 -b v3.21.0 https://github.com/osrg/gobgp.git /gobgp
 
 RUN cd /gobgp && \
     go get -u golang.org/x/net@v0.17.0 && \
@@ -13,23 +13,25 @@ RUN cd /gobgp && \
     go mod tidy && \
     CGO_ENABLED=0 go build -ldflags "-s -w" -o /usr/local/bin/gobgp /gobgp/cmd/gobgp
 
-RUN git clone -b ${KUBE_ROUTER_VERSION} https://github.com/cloudnativelabs/kube-router.git /kube-router
+RUN git -c advice.detachedHead=false clone --depth 1 -b ${KUBE_ROUTER_VERSION} https://github.com/cloudnativelabs/kube-router.git /kube-router
 
 RUN cd /kube-router && \
     export GIT_COMMIT=$(git describe --tags --dirty) && \
-    export BUILD_DATE="2023-07-17T00:00:00+0000" && \
+    export BUILD_DATE=$(git log -1 --date=format:%Y-%m-%dT%H:%M:%S%z --format=%cd) && \
     go get -u golang.org/x/net@v0.17.0 && \
     go get -u github.com/docker/distribution@v2.8.2 && \
-    go get -u github.com/docker/docker@v20.10.25 && \
+    go get -u github.com/docker/docker@v25.0.5 && \
     go get -u google.golang.org/grpc@v1.58.3 && \
     go mod tidy && \
     CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/cloudnativelabs/kube-router/pkg/version.Version=$GIT_COMMIT -X github.com/cloudnativelabs/kube-router/pkg/version.BuildDate=$BUILD_DATE" \
      -o /usr/local/bin/kube-router /kube-router/cmd/kube-router
 
 
-FROM alpine:3.18
+FROM docker.io/library/alpine:3.18.6
 ARG KUBE_ROUTER_VERSION
 RUN apk add --no-cache \
+      libcrypto3=3.1.4-r6 \
+      libssl3=3.1.4-r6 \
       'iptables=1.8.9-r2' \
       'ip6tables=1.8.9-r2' \
       ipset \


### PR DESCRIPTION
https://github.com/cloudnativelabs/kube-router/releases/tag/v1.6.1

* Use Go 1.21.9
* Update openssl and Docker to address CVEs
* Use shallow cloning of git repos and suppress detached head warnings
* Use the git commit date as build time