### PR TITLE
Fix armv7-ubuntu22-04 image

### DIFF
--- a/images/actions-runner/armv7-ubuntu22-04-0/Dockerfile
+++ b/images/actions-runner/armv7-ubuntu22-04-0/Dockerfile
@@ -17,16 +17,15 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    curl \
+    build-essential \
     ca-certificates \
+    curl \
     git \
     git-lfs \
     jq \
     sudo \
     unzip \
     zip \
-    gcc \
-    make \
     && rm -rf /var/lib/apt/lists/*
 
 RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \


### PR DESCRIPTION
We need the libc headers for cgo to work when running the integration tests. Install build-essential instead of gcc and make alone.