### PR TITLE
Bump CoreDNS to v1.11.3

### DIFF
--- a/images/coredns/1.11.3/Dockerfile
+++ b/images/coredns/1.11.3/Dockerfile
@@ -1,28 +1,34 @@
+ARG BUILDER_IMAGE=docker.io/library/golang:1.22.2-alpine3.19
+
 ARG \
-  VERSION=1.11.1 \
-  GIT_COMMIT=ae2bbc29be1aaae0b3ded5d188968a6c97bb3144 \
-  HASH=4e1cde1759d1705baa9375127eb405cd2f5031f9152947bb958a51fee5898d8c
+  VERSION=1.11.3 \
+  GIT_COMMIT=a7ed346585e30b99317d36e4d007b7b19a228ea5 \
+  HASH=b64e0c5970000595a0682e9a87ebbad5ef0db790c1b6efbba6e341211bdf3299
 
-FROM docker.io/library/golang:1.20.8-alpine3.18 as build
-ARG VERSION GIT_COMMIT HASH
+FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE as sources
+ARG VERSION HASH
+RUN --mount=type=tmpfs,target=/tmp \
+  set -euo pipefail \
+  && wget -O /tmp/src.tar.gz https://github.com/coredns/coredns/archive/refs/tags/v${VERSION}.tar.gz \
+  && { echo "$HASH" /tmp/src.tar.gz | sha256sum -c -; } \
+  && tar xf /tmp/src.tar.gz -C /go/src \
+  && mv /go/src/coredns-"$VERSION" /go/src/coredns
 
-ENV CGO_ENABLED=0
-
-RUN wget https://github.com/coredns/coredns/archive/refs/tags/v${VERSION}.tar.gz \
-  && { echo "${HASH} *v${VERSION}.tar.gz" | sha256sum -c -; } \
-  && tar xf "v${VERSION}.tar.gz" -C /go \
-  && rm -- "v${VERSION}.tar.gz"
-
-WORKDIR /go/coredns-$VERSION
-RUN go build -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$GIT_COMMIT"
-
-FROM gcr.io/distroless/static-debian12@sha256:98e138282ba524ff4f5124fec603f82ee2331df4ba981d169b3ded8bcd83ca52 as static
+FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE as build
+WORKDIR /go/src/coredns
+ARG VERSION GIT_COMMIT TARGETARCH
+ENV GOTOOLCHAIN=local CGO_ENABLED=0 GOARCH="$TARGETARCH"
+RUN --mount=from=sources,source=/go/src/coredns,target=/go/src/coredns \
+  --mount=type=cache,id=coredns-go-cache-$TARGETARCH,target=/root/.cache/go-build \
+  --mount=type=cache,id=coredns-go-mod-$VERSION,target=/go/pkg/mod \
+  --mount=type=tmpfs,target=/tmp \
+  go build -o /coredns -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$GIT_COMMIT"
 
 FROM scratch
 ARG VERSION
 
-COPY --from=build /go/coredns-$VERSION/coredns /coredns
-COPY --from=static /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /coredns /coredns
+COPY --from=gcr.io/distroless/static-debian12@sha256:41972110a1c1a5c0b6adb283e8aa092c43c31f7c5d79b8656fbffff2c3e61f05 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
https://github.com/coredns/coredns/releases/tag/v1.11.3

Bump Alpine/Go/distroless to the newest versions. Use cross-compilation for faster multi-platfrom image builds. Add some caching using an extra layer for the sources and some cache directories for the go cache and go mod cache. Specify GOTOOLCHAIN=local so that Go won't try to download another toolchain than the one from the base image.

See k0sproject/k0s#4356.