### PR TITLE
Add envoy v1.29.5, v1.30.2

### DIFF
--- a/images/envoy-distroless/v1.29.5/Dockerfile
+++ b/images/envoy-distroless/v1.29.5/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.29.3@sha256:3c8e339269db9fa842ad5b9942700a244197052f7c8b8adced36390f2b3a8860 as binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.29.5@sha256:ec6fc9d7478f37569b6971943b6b993c6670710a492c70b9a55e44ffb2da41c1 as binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:1c99fceaba16f833d6eb030c07d6304bce68f18350e1a0c69a85b8781afc00d9
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:53745e95f227cd66e8058d52f64efbbeb6c6af2c193e3c16981137e5083e6a32
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml

--- a/images/envoy-distroless/v1.30.2/Dockerfile
+++ b/images/envoy-distroless/v1.30.2/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.30.1@sha256:645582c5e845940c11b61d6203d1ded5095e3908b23c39a53450fc9940cc4989 as binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.30.2@sha256:5fe272f80c4f3b4d19d46fc376623dbb8bc6f08d3f39ac8e597e60f688ae644a as binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:1c99fceaba16f833d6eb030c07d6304bce68f18350e1a0c69a85b8781afc00d9
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:53745e95f227cd66e8058d52f64efbbeb6c6af2c193e3c16981137e5083e6a32
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/releases/tag/v1.30.2
https://github.com/envoyproxy/envoy/releases/tag/v1.29.5
https://github.com/envoyproxy/envoy/releases/tag/v1.29.4

Fixes CVE-2024-34362, CVE-2024-34363, CVE-2024-34364, CVE-2024-32974, CVE-2024-32975, CVE-2024-32976, and CVE-2024-23326.

Additionally, for 1.29, fixes CVE-2024-32475.