### PR TITLE
Envoy v1.29.8, v1.30.5 and v1.31.1 (CVE-2024-7264)

### DIFF
--- a/images/envoy-distroless/v1.29.8/Dockerfile
+++ b/images/envoy-distroless/v1.29.8/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.29.7@sha256:553b1e8c19b1e1c5941d3eca907518942b6412f315dfc7b58cca161282e322c6 AS binary
+# docker buildx imagetools inspect docker.io/envoyproxy/envoy-distroless:v1.29.8
+FROM docker.io/envoyproxy/envoy-distroless:v1.29.8@sha256:000962566ef908117897e939c4b76add266e277c2b740965d881d08faf52b86e AS binary
 
 FROM gcr.io/distroless/base-debian12:nonroot@sha256:a9899ccd9868bbd8913c67f6807410abecf766bc9e3c718eb6248f7b3dfb9819
 

--- a/images/envoy-distroless/v1.30.5/Dockerfile
+++ b/images/envoy-distroless/v1.30.5/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.30.4@sha256:10040cc5e1d97f6b9aa51ab9538f9c2961b8aa2647d8453dcb3c6c09ae424f18 AS binary
+# docker buildx imagetools inspect docker.io/envoyproxy/envoy-distroless:v1.30.5
+FROM docker.io/envoyproxy/envoy-distroless:v1.30.5@sha256:f9105acc862172b3e8e9d26db751580d121d04f77cdda1275ad0e85034e38a74 AS binary
 
 FROM gcr.io/distroless/base-debian12:nonroot@sha256:a9899ccd9868bbd8913c67f6807410abecf766bc9e3c718eb6248f7b3dfb9819
 

--- a/images/envoy-distroless/v1.31.1/Dockerfile
+++ b/images/envoy-distroless/v1.31.1/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.31.0@sha256:493daed56a2b1593881d530e82d51a0645fbe720fa602b4e9bc091b6b016d63b AS binary
+# docker buildx imagetools inspect docker.io/envoyproxy/envoy-distroless:v1.31.1
+FROM docker.io/envoyproxy/envoy-distroless:v1.31.1@sha256:524d924ef45e78a1bb6041c9f775af307904d008dc9d255c633f810f19a8f7bd AS binary
 
 FROM gcr.io/distroless/base-debian12:nonroot@sha256:a9899ccd9868bbd8913c67f6807410abecf766bc9e3c718eb6248f7b3dfb9819
 


### PR DESCRIPTION

- https://github.com/envoyproxy/envoy/releases/tag/v1.29.8
- https://github.com/envoyproxy/envoy/releases/tag/v1.30.5
- https://github.com/envoyproxy/envoy/releases/tag/v1.31.1
