### PR TITLE
Include ip6tables binaries in calico-node

### DIFF
--- a/images/calico-node/v3.28.1-1/Dockerfile
+++ b/images/calico-node/v3.28.1-1/Dockerfile
@@ -107,6 +107,7 @@ COPY --from=bird /bird* /usr/bin/
 # Copy iptables and wrappers
 COPY --from=iptables /usr/local/sbin/xtables-* /sbin/
 COPY --from=iptables /usr/local/sbin/iptables* /sbin/
+COPY --from=iptables /usr/local/sbin/ip6tables* /sbin/
 COPY --from=iptables-wrapper /iptables-wrappers/bin/iptables-wrapper /
 COPY --from=iptables-wrapper /iptables-wrappers/iptables-wrapper-installer.sh /
 


### PR DESCRIPTION
It was reported to us that some times calico detected legacy iptables mode instead of nft.

This ultimately happened because `ip6tables-nft-save` was not present This PR fixes it by including ever ip6tables binary.

I provided this image to the reporter and he's not able to reproduce anymore.