### PR TITLE
Make calico v3.28.2 use iptables 1.8.9

### DIFF
--- a/images/calico-node/v3.28.2-0/Dockerfile
+++ b/images/calico-node/v3.28.2-0/Dockerfile
@@ -8,8 +8,9 @@ ARG \
   # https://github.com/projectcalico/calico/blob/v3.28.2/metadata.mk#L29
   BIRD_VERSION=v0.3.3-208-g1e2ff99d \
   BUILDER_IMAGE=docker.io/library/golang:1.22.7-alpine3.20 \
-  IPTABLES_WRAPPERS_VERSION=06cad2ec6cb5ed0945b383fb185424c0a67f55eb \
-  IPTABLES_VERSION=1.8.10
+  IPTABLES_WRAPPERS_VERSION=f6ef44b2c449cca8f005b32dea9a4b497202dbef \
+  IPTABLES_VERSION=1.8.9
+
 
 FROM $BUILDER_IMAGE AS builder
 


### PR DESCRIPTION
Right before releasing we noticed an iptables version discrepancy across components. We're setting it back to 1.8.9 to avoid potential problems.