### PR TITLE
Add envoy v1.29.10, v1.30.7, v1.31.3

### DIFF
--- a/images/envoy-distroless/v1.29.10/Dockerfile
+++ b/images/envoy-distroless/v1.29.10/Dockerfile
@@ -1,7 +1,6 @@
-# docker buildx imagetools inspect docker.io/envoyproxy/envoy-distroless:v1.29.8
-FROM docker.io/envoyproxy/envoy-distroless:v1.29.8@sha256:000962566ef908117897e939c4b76add266e277c2b740965d881d08faf52b86e AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.29.10@sha256:280fba1031c6610e3509cff146d9b10dfc78f83b79760248e5615580a571c5fc AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:a9899ccd9868bbd8913c67f6807410abecf766bc9e3c718eb6248f7b3dfb9819
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:c3584d9160af7bbc6a0a6089dc954d0938bb7f755465bb4ef4265aad0221343e
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml

--- a/images/envoy-distroless/v1.30.7/Dockerfile
+++ b/images/envoy-distroless/v1.30.7/Dockerfile
@@ -1,7 +1,6 @@
-# docker buildx imagetools inspect docker.io/envoyproxy/envoy-distroless:v1.30.5
-FROM docker.io/envoyproxy/envoy-distroless:v1.30.5@sha256:f9105acc862172b3e8e9d26db751580d121d04f77cdda1275ad0e85034e38a74 AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.30.7@sha256:4e8ffe06c3b065d784986eef87312717c510fde25169dba39396113feb9b562a AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:a9899ccd9868bbd8913c67f6807410abecf766bc9e3c718eb6248f7b3dfb9819
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:c3584d9160af7bbc6a0a6089dc954d0938bb7f755465bb4ef4265aad0221343e
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml

--- a/images/envoy-distroless/v1.31.3/Dockerfile
+++ b/images/envoy-distroless/v1.31.3/Dockerfile
@@ -1,7 +1,6 @@
-# docker buildx imagetools inspect docker.io/envoyproxy/envoy-distroless:v1.31.1
-FROM docker.io/envoyproxy/envoy-distroless:v1.31.1@sha256:524d924ef45e78a1bb6041c9f775af307904d008dc9d255c633f810f19a8f7bd AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.31.3@sha256:8a3f187987ffb8488f0ca1a07e5e0a9ae191733436713c5890bc18a4e67dece9 AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:a9899ccd9868bbd8913c67f6807410abecf766bc9e3c718eb6248f7b3dfb9819
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:c3584d9160af7bbc6a0a6089dc954d0938bb7f755465bb4ef4265aad0221343e
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/releases/tag/v1.29.9
https://github.com/envoyproxy/envoy/releases/tag/v1.29.10

https://github.com/envoyproxy/envoy/releases/tag/v1.30.6
https://github.com/envoyproxy/envoy/releases/tag/v1.30.7

https://github.com/envoyproxy/envoy/releases/tag/v1.31.2
https://github.com/envoyproxy/envoy/releases/tag/v1.31.3

Fixes CVE-2024-45806, CVE-2024-45808, CVE-2024-45809 and CVE-2024-45810.
Additionally, for v1.31, fixes CVE-2024-45807.