### PR TITLE
kube-router: call iptables-wrapper-installer script again

### DIFF
--- a/images/kube-router/v2.2.1-iptables1.8.9-1/Dockerfile
+++ b/images/kube-router/v2.2.1-iptables1.8.9-1/Dockerfile
@@ -50,6 +50,8 @@ RUN --mount=from=build-iptables-wrapper,source=/go/iptables-wrapper,target=/run/
   apk add --no-cache \
     'iptables=~1.8.9' \
     'ip6tables=~1.8.9' \
+    'libcrypto3=~3.1.7-r1' \
+    'libssl3=~3.1.7-r1' \
     ipset \
     iproute2 \
     ipvsadm \


### PR DESCRIPTION
v2.2.1-iptables1.8.9-0 -> v2.2.1-iptables1.8.9-1

Use a similar setup for the iptables-wrapper as in kube-proxy, and run the installer script again so that the iptables-wrapper will do its job. Bump Alpine to 3.20 and Go to v1.23.4. Bundle common tool installations in a base image and remove unused
references to the KUBE_ROUTER_VERSION build argument. Pin libcrypto3 and libssl3 for CVE-2024-9143.

Fixes:

* #103