### PR TITLE
Bump Envoy to v1.29.11, v1.30.8, v1.31.4, v1.32.2

### DIFF
--- a/images/envoy-distroless/v1.29.11/Dockerfile
+++ b/images/envoy-distroless/v1.29.11/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.29.10@sha256:280fba1031c6610e3509cff146d9b10dfc78f83b79760248e5615580a571c5fc AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.29.11@sha256:b37caf73d76e0c95f7cfff839d274afde752e52f7ae57628a60ff439be96d135 AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:c3584d9160af7bbc6a0a6089dc954d0938bb7f755465bb4ef4265aad0221343e
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:6d4a4f40e93615df1677463ca56456379cc3a4e2359308c9e72bc60ffc4a12a9
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml

--- a/images/envoy-distroless/v1.30.8/Dockerfile
+++ b/images/envoy-distroless/v1.30.8/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.30.7@sha256:4e8ffe06c3b065d784986eef87312717c510fde25169dba39396113feb9b562a AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.30.8@sha256:184d9267cb35a34d3d64b685dc06b279d8efaafda43ce9a5822c7ff19c26dfc1 AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:c3584d9160af7bbc6a0a6089dc954d0938bb7f755465bb4ef4265aad0221343e
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:6d4a4f40e93615df1677463ca56456379cc3a4e2359308c9e72bc60ffc4a12a9
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml

--- a/images/envoy-distroless/v1.31.4/Dockerfile
+++ b/images/envoy-distroless/v1.31.4/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.31.3@sha256:8a3f187987ffb8488f0ca1a07e5e0a9ae191733436713c5890bc18a4e67dece9 AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.31.4@sha256:5558a8554a218daf2f2ae2ad27148c83c7f9d551dd94a00c42d61d0f1f507ea1 AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:c3584d9160af7bbc6a0a6089dc954d0938bb7f755465bb4ef4265aad0221343e
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:6d4a4f40e93615df1677463ca56456379cc3a4e2359308c9e72bc60ffc4a12a9
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml

--- a/images/envoy-distroless/v1.32.2/Dockerfile
+++ b/images/envoy-distroless/v1.32.2/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.31.3@sha256:8a3f187987ffb8488f0ca1a07e5e0a9ae191733436713c5890bc18a4e67dece9 AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.32.2@sha256:11de2e75de4dce39e38ff8da8077096ba9f6f784d6f6866a663fe8d2c809227e AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:c3584d9160af7bbc6a0a6089dc954d0938bb7f755465bb4ef4265aad0221343e
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:6d4a4f40e93615df1677463ca56456379cc3a4e2359308c9e72bc60ffc4a12a9
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml


### PR DESCRIPTION
https://www.envoyproxy.io/docs/envoy/v1.32.2/version_history/v1.32/v1.32
https://www.envoyproxy.io/docs/envoy/v1.32.2/version_history/v1.31/v1.31.4
https://www.envoyproxy.io/docs/envoy/v1.32.2/version_history/v1.30/v1.30.8
https://www.envoyproxy.io/docs/envoy/v1.32.2/version_history/v1.29/v1.29.11

Fixes CVE-2024-25629.