### PR TITLE
Build images for riscv64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,12 @@ jobs:
             etcd*) platforms=linux/amd64,linux/arm64;;
           esac
 
+          case "$FOLDER" in
+            apiserver-network-proxy-agent*|coredns*|kube-proxy*|kube-router*)
+              platforms="$platforms,linux/riscv64"
+              ;;
+          esac
+
           trivyResults="${FOLDER//\//-}-trivy.sarif"
 
           {


### PR DESCRIPTION
enable riscv64 images of:

- apiserver-network-proxy-agent
- coredns
- kube-proxy
- kube-router