### PR TITLE
Add envoy v1.29.12, v1.30.9, v1.31.5, v1.32.3

### DIFF
--- a/images/envoy-distroless/v1.29.12/Dockerfile
+++ b/images/envoy-distroless/v1.29.12/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.29.11@sha256:b37caf73d76e0c95f7cfff839d274afde752e52f7ae57628a60ff439be96d135 AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.29.12@sha256:23b8962edd99e87c7dc39eabd8e4bd9dfb07463bed3eb7e842db786c60f82264 AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:6d4a4f40e93615df1677463ca56456379cc3a4e2359308c9e72bc60ffc4a12a9
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:97d15218016debb9b6700a8c1c26893d3291a469852ace8d8f7d15b2f156920f
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml

--- a/images/envoy-distroless/v1.30.9/Dockerfile
+++ b/images/envoy-distroless/v1.30.9/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.30.8@sha256:184d9267cb35a34d3d64b685dc06b279d8efaafda43ce9a5822c7ff19c26dfc1 AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.30.9@sha256:bdf7f81466e7db37e2395654f34ff3d3bb31851030fa1af7c46299e71c0ac640 AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:6d4a4f40e93615df1677463ca56456379cc3a4e2359308c9e72bc60ffc4a12a9
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:97d15218016debb9b6700a8c1c26893d3291a469852ace8d8f7d15b2f156920f
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml

--- a/images/envoy-distroless/v1.31.5/Dockerfile
+++ b/images/envoy-distroless/v1.31.5/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.31.4@sha256:5558a8554a218daf2f2ae2ad27148c83c7f9d551dd94a00c42d61d0f1f507ea1 AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.31.5@sha256:39966dcd78ccd1283947596827df39e2fb674febf5a9dc1be639dc08b706194f AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:6d4a4f40e93615df1677463ca56456379cc3a4e2359308c9e72bc60ffc4a12a9
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:97d15218016debb9b6700a8c1c26893d3291a469852ace8d8f7d15b2f156920f
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml

--- a/images/envoy-distroless/v1.32.3/Dockerfile
+++ b/images/envoy-distroless/v1.32.3/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/envoyproxy/envoy-distroless:v1.32.2@sha256:11de2e75de4dce39e38ff8da8077096ba9f6f784d6f6866a663fe8d2c809227e AS binary
+FROM docker.io/envoyproxy/envoy-distroless:v1.32.3@sha256:375aab0d80b3c0e1b42a776b4cb1743ed79012032051d2da19cbc93ea884fb81 AS binary
 
-FROM gcr.io/distroless/base-debian12:nonroot@sha256:6d4a4f40e93615df1677463ca56456379cc3a4e2359308c9e72bc60ffc4a12a9
+FROM gcr.io/distroless/base-debian12:nonroot@sha256:97d15218016debb9b6700a8c1c26893d3291a469852ace8d8f7d15b2f156920f
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/releases/tag/v1.29.12
https://github.com/envoyproxy/envoy/releases/tag/v1.30.9
https://github.com/envoyproxy/envoy/releases/tag/v1.31.5
https://github.com/envoyproxy/envoy/releases/tag/v1.32.3

Fixes CVE-2024-53269, CVE-2024-53270 and CVE-2024-53271.