### PR TITLE
Coredns 1.12.1

### DIFF
--- a/images/coredns/1.12.1/Dockerfile
+++ b/images/coredns/1.12.1/Dockerfile
@@ -1,9 +1,9 @@
-ARG BUILDER_IMAGE=docker.io/library/golang:1.23.4-alpine3.20
+ARG BUILDER_IMAGE=docker.io/library/golang:1.24.2-alpine3.21
 
 ARG \
-  VERSION=1.12.0 \
-  GIT_COMMIT=51e11f166ef6c247a78e9e15468647c593b79b9f \
-  HASH=71a585f7d41cd07a0839788bd3bb17bcc26501711c857eeae7cae2f1f654eeac
+  VERSION=1.12.1 \
+  GIT_COMMIT=707c7c10acd52cb94e959e76ae233d9b76af0854 \
+  HASH=665b2096611b960572b40ad7e943e9c6cca58da5f3885e148868578b15fbf8ef
 
 FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS sources
 ARG VERSION HASH
@@ -23,12 +23,13 @@ RUN --mount=from=sources,source=/go/src/coredns,target=/go/src/coredns \
   --mount=type=cache,id=coredns-go-mod-$VERSION,target=/go/pkg/mod \
   --mount=type=tmpfs,target=/tmp \
   go build -o /coredns -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$GIT_COMMIT"
+RUN apk add --no-cache ca-certificates-bundle
 
 FROM scratch
 ARG VERSION
 
 COPY --from=build /coredns /coredns
-COPY --from=gcr.io/distroless/static-debian12@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
https://github.com/coredns/coredns/releases/tag/v1.12.1

This also enables build for riscv64