### PR TITLE
Allow coreDNS to run as non-root

### DIFF
--- a/images/coredns/1.12.2-1/Dockerfile
+++ b/images/coredns/1.12.2-1/Dockerfile
@@ -23,7 +23,8 @@ RUN --mount=from=sources,source=/go/src/coredns,target=/go/src/coredns \
   --mount=type=cache,id=coredns-go-mod-$VERSION,target=/go/pkg/mod \
   --mount=type=tmpfs,target=/tmp \
   go build -o /coredns -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$GIT_COMMIT"
-RUN apk add --no-cache ca-certificates-bundle
+RUN apk add --no-cache ca-certificates-bundle libcap-setcap
+RUN setcap cap_net_bind_service=+ep /coredns
 
 FROM scratch
 LABEL org.opencontainers.image.licenses="Apache-2.0" \
@@ -32,6 +33,7 @@ ARG VERSION
 
 COPY --from=build /coredns /coredns
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+USER 65532:65532
 
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
Currently coreDNS runs as UID 0, which isn't nearly as bad as it sounds because we drop all the capabilities except CAP_NET_BIND.

This is required for: https://github.com/k0sproject/k0s/issues/5956