### PR TITLE
Bump calico to v3.29.6-0

### DIFF
--- a/images/calico-cni/v3.29.6-0/Dockerfile
+++ b/images/calico-cni/v3.29.6-0/Dockerfile
@@ -1,20 +1,20 @@
 # https://github.com/projectcalico/calico/blob/v3.29.2/cni-plugin/Dockerfile
 
 ARG \
-  VERSION=3.29.4\
-  HASH=6d2396fde36ba59ad55a92b5b66643adcc9ee13bb2b3986b1014e2f8f95fa861 \
-  # https://github.com/projectcalico/calico/blob/v3.29.4/metadata.mk#L52-L55
+  VERSION=3.29.6\
+  HASH=927e35d130d0413399735dc401e8448c783794cb8bb9e169ccdc7b00f516a698 \
+  # https://github.com/projectcalico/calico/blob/v3.29.6/metadata.mk#L52-L55
   # Calico has FLANNEL_VERSION=main branch and CNI_VERSION=master.
-  # v3.29.4 was released 2025-05-21: https://github.com/projectcalico/calico/releases/tag/v3.29.4
+  # v3.29.6 was released 2025-09-19: https://github.com/projectcalico/calico/releases/tag/v3.29.6
   #
-  # https://github.com/projectcalico/calico/blob/v3.29.4/cni-plugin/Makefile#L169
-  # https://github.com/projectcalico/flannel-cni-plugin/commits/main/?since=2024-09-12&until=2025-05-26
+  # https://github.com/projectcalico/calico/blob/v3.29.6/cni-plugin/Makefile#L169
+  # https://github.com/projectcalico/flannel-cni-plugin/commits/main/?since=2024-09-12&until=2025-09-19
   FLANNEL_VERSION=5a977558e9fbbf93ff7ba927847fbca194e02416 \
   #
-  # https://github.com/projectcalico/calico/blob/v3.29.4/cni-plugin/Makefile#L150
-  # https://github.com/projectcalico/containernetworking-plugins/commits/master/?since=2025-01-27&until=2025-03-26
+  # https://github.com/projectcalico/calico/blob/v3.29.6/cni-plugin/Makefile#L150
+  # https://github.com/projectcalico/containernetworking-plugins/commits/master/?since=2025-01-27&until=2025-09-19
   CNI_VERSION=9ffe547cb3b66f80dd32a00fc69a6d0082b55321 \
-  BUILDER_IMAGE=docker.io/library/golang:1.24.4-alpine3.21
+  BUILDER_IMAGE=docker.io/library/golang:1.24.7-alpine3.21
 
 FROM $BUILDER_IMAGE AS builder
 
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 go build \
   -v -buildvcs=false \
   -o /out/opt/cni/bin/ \
   -ldflags "-s -w -X main.VERSION=v$VERSION" \
-  ./cni-plugin/cmd/calico ./cni-plugin/cmd/install 
+  ./cni-plugin/cmd/calico ./cni-plugin/cmd/install
 
 RUN set -e \
   && cd /out/opt/cni/bin \
@@ -43,7 +43,7 @@ RUN mkdir -p /go/flannel
 WORKDIR /go/flannel
 
 RUN git clone --single-branch https://github.com/projectcalico/flannel-cni-plugin.git /go/flannel \
-  && git reset --hard $FLANNEL_VERSION 
+  && git reset --hard $FLANNEL_VERSION
 
 RUN make build_linux
 

--- a/images/calico-kube-controllers/v3.29.6-0/Dockerfile
+++ b/images/calico-kube-controllers/v3.29.6-0/Dockerfile
@@ -1,10 +1,10 @@
 # https://github.com/projectcalico/calico/blob/v3.29.1/kube-controllers/Dockerfile
 
 ARG \
-  VERSION=3.29.4 \
-  HASH=6d2396fde36ba59ad55a92b5b66643adcc9ee13bb2b3986b1014e2f8f95fa861 
+  VERSION=3.29.6 \
+  HASH=927e35d130d0413399735dc401e8448c783794cb8bb9e169ccdc7b00f516a698
 
-FROM docker.io/library/golang:1.24.4-alpine3.21 AS builder
+FROM docker.io/library/golang:1.24.7-alpine3.21 AS builder
 
 ARG VERSION HASH
 RUN wget https://github.com/projectcalico/calico/archive/refs/tags/v$VERSION.tar.gz \

--- a/images/calico-node/v3.29.6-0/Dockerfile
+++ b/images/calico-node/v3.29.6-0/Dockerfile
@@ -1,13 +1,13 @@
-# https://github.com/projectcalico/calico/blob/v3.29.4/node/Dockerfile.amd64
+# https://github.com/projectcalico/calico/blob/v3.29.6/node/Dockerfile.amd64
 
 ARG \
-  VERSION=3.29.4 \
-  HASH=6d2396fde36ba59ad55a92b5b66643adcc9ee13bb2b3986b1014e2f8f95fa861 \
+  VERSION=3.29.6 \
+  HASH=927e35d130d0413399735dc401e8448c783794cb8bb9e169ccdc7b00f516a698 \
   IPSET_VERSION=7.23 \
   IPSET_HASH=5a43c790abf157a55db5a9a22cb5f28a225f5c7969beda81566a2259aa82c9d852979eb805b11b4347f47c6a0c2cc4de6f14e4733bee5b562844422a45fb9dab \
-  # https://github.com/projectcalico/calico/blob/v3.29.4/metadata.mk#L36
+  # https://github.com/projectcalico/calico/blob/v3.29.6/metadata.mk#L36
   BIRD_VERSION=v0.3.3-211-g9111ec3c \
-  BUILDER_IMAGE=docker.io/library/golang:1.24.4-alpine3.21 \
+  BUILDER_IMAGE=docker.io/library/golang:1.24.7-alpine3.21 \
   IPTABLES_WRAPPERS_VERSION=f6ef44b2c449cca8f005b32dea9a4b497202dbef \
   IPTABLES_VERSION=1.8.11
 


### PR DESCRIPTION
Calico v3.29.4 -> v3.29.6
Golang 1.24.4 -> 1.24.7