### PR TITLE
Bump kube router v2.6.0

### DIFF
--- a/images/kube-router/v2.6.0-iptables1.8.11-0/Dockerfile
+++ b/images/kube-router/v2.6.0-iptables1.8.11-0/Dockerfile
@@ -1,6 +1,6 @@
-ARG KUBE_ROUTER_VERSION=v2.5.0
+ARG KUBE_ROUTER_VERSION=v2.6.0
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.2-alpine3.21 AS build-base
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.25.1-alpine3.22 AS build-base
 RUN apk add --no-interactive --no-cache git make curl
 ENV GOTOOLCHAIN=local
 


### PR DESCRIPTION
Kube-router v2.5.0 -> v2.6.0
Golang      1.24.2 -> 1.25.1
Alpine      3.21   -> 3.22