### PR TITLE
Add pushgateway-ttl image building

### DIFF
--- a/images/pushgateway-ttl/1.4.0-k0s.1/Dockerfile
+++ b/images/pushgateway-ttl/1.4.0-k0s.1/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.26-alpine AS builder
+
+RUN apk add git make curl
+
+RUN git clone -b v1.4.0 https://github.com/dinumathai/pushgateway.git
+
+WORKDIR pushgateway
+
+ADD patches/*.patch .
+
+# Apply patches, mainly to update Go dependencies
+RUN for patch in *.patch; do \
+        echo "Applying $patch"; \
+        git apply "$patch"; \
+    done
+
+RUN go mod tidy && go mod vendor && \
+    make common-build PROMU_VERSION=0.18.0
+
+FROM scratch
+
+COPY --from=builder /go/pushgateway/pushgateway /bin/pushgateway
+
+USER 65534
+
+ENTRYPOINT [ "/bin/pushgateway" ]

--- a/images/pushgateway-ttl/1.4.0-k0s.1/Dockerfile
+++ b/images/pushgateway-ttl/1.4.0-k0s.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.1-alpine3.23 AS builder
 
 RUN apk add git make curl
 

--- a/images/pushgateway-ttl/1.4.0-k0s.1/patches/01_go.mod.patch
+++ b/images/pushgateway-ttl/1.4.0-k0s.1/patches/01_go.mod.patch
@@ -1,0 +1,60 @@
+diff --git a/go.mod b/go.mod
+index 3baf49a..c37bb9d 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,22 +1,43 @@
+ module github.com/prometheus/pushgateway
+ 
++go 1.25.0
++
+ require (
+ 	github.com/go-kit/kit v0.10.0
+-	github.com/golang/protobuf v1.4.3
+-	github.com/google/go-cmp v0.5.2 // indirect
+-	github.com/kr/text v0.2.0 // indirect
++	github.com/golang/protobuf v1.5.4
+ 	github.com/matttproud/golang_protobuf_extensions v1.0.1
+-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+-	github.com/prometheus/client_golang v1.9.0
++	github.com/prometheus/client_golang v1.13.0
+ 	github.com/prometheus/client_model v0.2.0
+-	github.com/prometheus/common v0.15.0
+-	github.com/prometheus/exporter-toolkit v0.5.1
+-	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
++	github.com/prometheus/common v0.37.0
++	github.com/prometheus/exporter-toolkit v0.7.2
+ 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546
+-	github.com/stretchr/testify v1.6.1 // indirect
+-	golang.org/x/tools v0.0.0-20201215192005-fa10ef0b8743 // indirect
+ 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+ )
+ 
+-go 1.11
++require (
++	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
++	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
++	github.com/beorn7/perks v1.0.1 // indirect
++	github.com/cespare/xxhash/v2 v2.1.2 // indirect
++	github.com/go-kit/log v0.2.0 // indirect
++	github.com/go-logfmt/logfmt v0.5.1 // indirect
++	github.com/jpillora/backoff v1.0.0 // indirect
++	github.com/julienschmidt/httprouter v1.3.0 // indirect
++	github.com/kr/text v0.2.0 // indirect
++	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
++	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
++	github.com/pkg/errors v0.9.1 // indirect
++	github.com/prometheus/procfs v0.8.0 // indirect
++	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
++	github.com/stretchr/testify v1.6.1 // indirect
++	golang.org/x/crypto v0.49.0 // indirect
++	golang.org/x/net v0.51.0 // indirect
++	golang.org/x/oauth2 v0.36.0 // indirect
++	golang.org/x/sys v0.42.0 // indirect
++	golang.org/x/text v0.35.0 // indirect
++	golang.org/x/tools/godoc v0.1.0-deprecated // indirect
++	google.golang.org/appengine v1.6.6 // indirect
++	google.golang.org/protobuf v1.36.10 // indirect
++	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
++	gopkg.in/yaml.v2 v2.4.0 // indirect
++)


### PR DESCRIPTION
With this we can retire it as a separate repo at https://github.com/k0sproject/pushgateway-ttl-builder/

Instead of doing go get -u github.com/foo/bar@1.2.3 updates, consolidate all the go dep updates into a git patch apply.

Switch the image to base from scratch since there's no need for Alpine or other base.