### PR TITLE
Pin trivy action to commit of 0.35.0 tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
           tags: ${{ steps.image.outputs.image-name }}
 
       - name: Run Trivy vulnerability
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.image.outputs.image-name }}
           ignore-unfixed: true

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -48,7 +48,7 @@ jobs:
           hack/docker-buildx.sh --progress=plain --load -t quay.io/k0sproject/${{ matrix.image_tag }}-${{ github.sha }} ${{ steps.imagepath.outputs.value }}
       - name: Run Trivy vulnerability scanner
         if: ${{ contains(needs.prepare.outputs.changed_files, steps.imagepath.outputs.base) }}
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: 'quay.io/k0sproject/${{ matrix.image_tag }}-${{ github.sha }}'
           format: 'table'


### PR DESCRIPTION
Since the trivy action repo has been compromised and some (all?) tags rewritten, we need to pin to a direct commit so avoid such things leaking to our pipelines.