### PR TITLE
Upload SARIF file in separate job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
             [ $skip -ne 0 ] || buildPlatforms+=("$p")
           done
 
+          # Don't forget to adjust the upload-sarif job when changing this.
           trivyResults="${FOLDER//\//-}-trivy.sarif"
 
           {
@@ -177,14 +178,36 @@ jobs:
           output: ${{ steps.image.outputs.trivy-results }}
 
       - name: Upload Trivy scan results
-        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ steps.image.outputs.trivy-results }}
           path: ${{ steps.image.outputs.trivy-results }}
 
-      - name: Upload Trivy scan results to GitHub Security tab
-        if: github.event_name == 'push'
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+  upload-sarif:
+    runs-on: ubuntu-22.04
+    needs: [prepare, images]
+    if: github.event_name == 'push' && needs.prepare.outputs.matrix != '{"skip":1}'
+    permissions:
+      security-events: write
+    strategy:
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+      fail-fast: false
+
+    steps:
+      - name: Prepare
+        id: prepare
+        env:
+          FOLDER: ${{ matrix.folder }}
+        run: |
+          set -euo pipefail
+          echo "sarif-file=${FOLDER//\//-}-trivy.sarif" | tee -- "$GITHUB_OUTPUT"
+
+      - name: Download Trivy scan results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          sarif_file: ${{ steps.image.outputs.trivy-results }}
+          name: ${{ steps.prepare.outputs.sarif-file }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.34.1
+        with:
+          sarif_file: ${{ steps.prepare.outputs.sarif-file }}


### PR DESCRIPTION
So we can scope the required permissions just to the step that needs them. Since we're using a dynamic matrix build, we can't reliably expose each result filename as a separate job output. That's why we need to duplicate the file name generation logic.

See: https://github.com/github/codeql-action/tree/v4.34.1?tab=readme-ov-file#workflow-permissions