### PR TITLE
Add pause 3.10.2

### DIFF
--- a/images/pause/3.10.2-0/Dockerfile
+++ b/images/pause/3.10.2-0/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/library/alpine:3.21.3 AS build
-# https://github.com/kubernetes/kubernetes/blob/821bc2e15e3abadb996d477f2bfb59466cec01e0/build/pause/Makefile#L20
-ENV VERSION=3.10.1
-ENV HASH=26fe80855d14b50136986bc9806b96e72124a97e
+# https://github.com/kubernetes/kubernetes/blob/e6bea155c582846cfc43bf77ebc342b4cb83c637/build/pause/Makefile#L20
+ENV VERSION=3.10.2
+ENV HASH=e6bea155c582846cfc43bf77ebc342b4cb83c637
 
 RUN apk add --no-cache gcc musl-dev binutils
 

--- a/images/pause/3.10.2-0/Dockerfile
+++ b/images/pause/3.10.2-0/Dockerfile
@@ -1,0 +1,17 @@
+FROM docker.io/library/alpine:3.21.3 AS build
+# https://github.com/kubernetes/kubernetes/blob/821bc2e15e3abadb996d477f2bfb59466cec01e0/build/pause/Makefile#L20
+ENV VERSION=3.10.1
+ENV HASH=26fe80855d14b50136986bc9806b96e72124a97e
+
+RUN apk add --no-cache gcc musl-dev binutils
+
+# https://github.com/kubernetes/kubernetes/blob/master/build/pause/linux/pause.c
+RUN wget https://github.com/kubernetes/kubernetes/raw/$HASH/build/pause/linux/pause.c
+RUN gcc -Os -static -DVERSION=$VERSION -o pause pause.c && strip pause
+
+FROM scratch
+LABEL org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/kubernetes/kubernetes"
+COPY --from=build /pause /pause
+USER 65535:65535
+ENTRYPOINT ["/pause"]


### PR DESCRIPTION
Basically a no-op version number bump, but this gives us the possibility to publish a new image that will be built for RISC-V, as well.

https://github.com/kubernetes/kubernetes/commit/e6bea155c582846cfc43bf77ebc342b4cb83c637