### PR TITLE
Add Traefik v3.6.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,7 @@ jobs:
           case "$FOLDER" in
           envoy*) unsupportedPlatforms=(linux/arm/v7 linux/riscv64) ;;
           actions-runner*) unsupportedPlatforms=(linux/riscv64) ;;
+          traefik*) defaultPlatforms+=(windows/amd64) ;;
           *) unsupportedPlatforms=() ;;
           esac
 
@@ -126,6 +127,11 @@ jobs:
           persist-credentials: false
           show-progress: false
 
+      - name: Determine SOURCE_DATE_EPOCH
+        run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+          echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" >>"$GITHUB_ENV"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
@@ -134,6 +140,11 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+              # When too many workers are running, it can actually freeze the builder.
+              max-parallelism = 4
 
       - name: Login to Quay
         if: startsWith(steps.image.outputs.image-name, 'quay.io/')
@@ -165,8 +176,8 @@ jobs:
           context: ${{ format('images/{0}', matrix.folder) }}
           build-contexts: ${{ join(fromJSON(steps.build-contexts.outputs.list), '\n') }}
           platforms: ${{ steps.image.outputs.platforms }}
-          push: true
           tags: ${{ steps.image.outputs.image-name }}
+          outputs: type=image,push=true,rewrite-timestamp=true
 
       - name: Run Trivy vulnerability
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/images/traefik/v3.6.13-k0s.0/Dockerfile
+++ b/images/traefik/v3.6.13-k0s.0/Dockerfile
@@ -1,0 +1,59 @@
+ARG \
+  VERSION=3.6.13 \
+  HASH=eeaf33e6311ec6ca9fc4e6d6aab95d06f942ff7eb54170b94856569296083521 \
+  BUILDIMAGE=docker.io/library/golang:1.26.2-alpine3.23 \
+  DISTROLESS_BASEIMAGE=gcr.io/distroless/static-debian13:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39 \
+  HPC_BASEIMAGE=mcr.microsoft.com/oss/v2/kubernetes/windows-host-process-containers-base-image:2.0.0@sha256:97a4f486986c5e87e8fcc335f12ee042fcb9265d668e5d9acd75e24ea7873635
+
+FROM --platform=$BUILDPLATFORM $BUILDIMAGE AS sources
+ENV GOTOOLCHAIN=local GOTELEMETRY=off
+WORKDIR /go/src/traefik
+ARG VERSION HASH
+RUN --mount=type=tmpfs,target=/tmp \
+  set -euo pipefail \
+  && wget -qO /tmp/sources.tar.gz https://github.com/traefik/traefik/archive/refs/tags/v$VERSION.tar.gz \
+  && { echo $HASH /tmp/sources.tar.gz | sha256sum -c -; } || { sha256sum /tmp/sources.tar.gz; exit 1; } \
+  && tar xf /tmp/sources.tar.gz --strip-components=1
+RUN go mod download
+
+
+FROM sources AS builder
+RUN apk add --no-cache make
+
+
+FROM builder AS binary
+ARG TARGETOS TARGETARCH SOURCE_DATE_EPOCH
+RUN --mount=type=cache,id=calico-gocache-$TARGETOS-$TARGETARCH,target=/root/.cache/go-build \
+  --network=none \
+  `# https://github.com/traefik/traefik/blob/v3.6.13/Makefile#L59` \
+  && make --touch generate-webui \
+  && make binary \
+    GOOS=$TARGETOS \
+    GOARCH=$TARGETARCH \
+    `# https://github.com/traefik/traefik/pull/13009` \
+    'FLAGS[*]=-mod=readonly -trimpath -buildvcs=false' \
+    `# https://github.com/traefik/traefik/blob/v3.6.13/Makefile#L11` \
+    DATE=$(date -u -d @$SOURCE_DATE_EPOCH '+%Y-%m-%d_%I:%M:%S%p') \
+  && mkdir /out \
+  && mv -v dist/$TARGETOS/$TARGETARCH/traefik /out/
+
+
+FROM $DISTROLESS_BASEIMAGE AS final-linux
+COPY --from=binary /out/traefik /traefik
+ENTRYPOINT ["/traefik"]
+
+
+FROM $HPC_BASEIMAGE AS final-windows
+COPY --from=binary /out/traefik /traefik.exe
+ENTRYPOINT ["traefik.exe"]
+
+
+FROM final-$TARGETOS
+
+ARG VERSION
+LABEL org.opencontainers.image.title="Traefik for k0s" \
+  org.opencontainers.image.vendor=k0sproject \
+  org.opencontainers.image.source=https://github.com/k0sproject/image-builder \
+  org.opencontainers.image.licenses=Apache-2.0 \
+  org.opencontainers.image.url=https://traefik.io \
+  org.opencontainers.image.version="v$VERSION"


### PR DESCRIPTION
This is is a multi-platform image that works on Linux and Windows. Due to the fact that NLLB needs to run in the host network (i.e. it needs to be a HostProcess container on Windows), we can get away without specific OSVersion base images, as the DLLs are coming from the host. This makes it (more or less) straight forward: We just need to add windows/amd64 to the list of platforms, and just do a small hack in the Dockerfile to make it work.

Set and expose the `SOURCE_DATE_EPOCH` to the commit timestamp and let BuildKit rewrite the file timestamps. This allows for somewhat reproducible builds.

Cap BuildKit's parallelism at 4. Otherwise, so many parallel image builds might fry the public GitHub runner instances.