### PR TITLE
Add Windows support to konnectivity-agent image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,11 @@ jobs:
           *) unsupportedPlatforms=() ;;
           esac
 
+          case "$FOLDER" in
+          apiserver-network-proxy*) includeWindows=true ;;
+          *) includeWindows= ;;
+          esac
+
           buildPlatforms=()
           for p in "${defaultPlatforms[@]}"; do
             skip=0
@@ -119,6 +124,7 @@ jobs:
             echo "image-name=$registry/$name:$tag"
             echo "platforms=$(IFS=',';  echo "${buildPlatforms[*]}")"
             echo "trivy-results=$trivyResults"
+            echo "include-windows=$includeWindows"
           } | tee -- "$GITHUB_OUTPUT"
 
       - name: Checkout
@@ -146,14 +152,6 @@ jobs:
               # When too many workers are running, it can actually freeze the builder.
               max-parallelism = 4
 
-      - name: Login to Quay
-        if: startsWith(steps.image.outputs.image-name, 'quay.io/')
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-          registry: quay.io
-
       - name: Collect additional build contexts
         id: build-contexts
         env:
@@ -169,15 +167,81 @@ jobs:
               'rtrimstr("\n") | split("\n") | "list=\(tojson)"' \
             | tee -- "$GITHUB_OUTPUT"
 
-      - name: Build agent
+      - name: Build - Multi-platform
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: ${{ format('images/{0}', matrix.folder) }}
           build-contexts: ${{ join(fromJSON(steps.build-contexts.outputs.list), '\n') }}
           platforms: ${{ steps.image.outputs.platforms }}
-          tags: ${{ steps.image.outputs.image-name }}
-          outputs: type=image,push=true,rewrite-timestamp=true
+          outputs: type=oci,dest=image.tar,rewrite-timestamp=true
+
+      - name: Build - Windows 2019
+        if: steps.image.outputs.include-windows != ''
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ${{ format('images/{0}', matrix.folder) }}
+          build-contexts: ${{ join(fromJSON(steps.build-contexts.outputs.list), '\n') }}
+          platforms: windows/amd64
+          build-args: WINDOWS_VERSION=2019
+          outputs: type=oci,dest=windows-2019.tar,rewrite-timestamp=true
+
+      - name: Build - Windows 2022
+        if: steps.image.outputs.include-windows != ''
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ${{ format('images/{0}', matrix.folder) }}
+          build-contexts: ${{ join(fromJSON(steps.build-contexts.outputs.list), '\n') }}
+          platforms: windows/amd64
+          build-args: WINDOWS_VERSION=2022
+          outputs: type=oci,dest=windows-2022.tar,rewrite-timestamp=true
+
+      - name: Build - Windows 2025
+        if: steps.image.outputs.include-windows != ''
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ${{ format('images/{0}', matrix.folder) }}
+          build-contexts: ${{ join(fromJSON(steps.build-contexts.outputs.list), '\n') }}
+          platforms: windows/amd64
+          build-args: WINDOWS_VERSION=2025
+          outputs: type=oci,dest=windows-2025.tar,rewrite-timestamp=true
+
+      - name: Combine images
+        id: combine
+        if: steps.image.outputs.include-windows != ''
+        run: |
+          digest=$(./index-append.sh combined image.tar windows-20{19,22,25}.tar)
+          tar cf combined.tar -C combined \
+            --sort=name \
+            --mtime=@0 \
+            --owner=0 --group=0 --numeric-owner \
+            --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+            blobs/ index.json oci-layout
+          mv combined.tar image.tar
+          rm windows-20{19,22,25}.tar
+          rm -rf combined
+          echo "digest=$digest" | tee -- "$GITHUB_OUTPUT"
+
+      - name: Install ORAS
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
+      - name: Login to Quay
+        if: startsWith(steps.image.outputs.image-name, 'quay.io/')
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+
+      - name: Push image
+        env:
+          IMAGE_NAME: "${{ steps.image.outputs.image-name }}"
+          DIGEST: "${{ steps.combine.outputs.digest || steps.build.outputs.digest }}"
+        run: oras cp -r --from-oci-layout -- image.tar@"$DIGEST" "$IMAGE_NAME"
 
       - name: Run Trivy vulnerability
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/images/apiserver-network-proxy-agent/v0.34.0-k0s.2/Dockerfile
+++ b/images/apiserver-network-proxy-agent/v0.34.0-k0s.2/Dockerfile
@@ -1,0 +1,42 @@
+ARG \
+  VERSION=0.34.0 \
+  HASH=f338b1db93558121252eec01113a9adcf542d2c23d6c63a092cf9d2ae95317ac \
+  DEFAULT_BASEIMAGE=gcr.io/distroless/static-debian12:nonroot@sha256:e8a4044e0b4ae4257efa45fc026c0bc30ad320d43bd4c1a7d5271bd241e386d0 \
+  RISCV_BASEIMAGE=ghcr.io/go-riscv/distroless/static-unstable:latest@sha256:0bd27d7ab1f1863abecdebe207870375364fddc1d0ae87179ef176403d04e27b
+
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.25.3-alpine3.22 AS build
+ENV CGO_ENABLED=0 GOTELEMETRY=off
+WORKDIR /go/src/kubernetes-sigs/apiserver-network-proxy
+
+ARG VERSION HASH
+RUN --mount=type=cache,id=konnectivity-go-modcache,target=/go/pkg/mod \
+  --mount=type=tmpfs,target=/tmp \
+  set -e \
+  && wget -qO /tmp/src.tar.gz https://github.com/kubernetes-sigs/apiserver-network-proxy/archive/refs/tags/v$VERSION.tar.gz \
+  && { printf '%s */tmp/src.tar.gz' "$HASH" | sha256sum -c -; } \
+  && tar xf /tmp/src.tar.gz --strip-components=1 \
+  && go mod download -x
+
+ARG TARGETARCH
+ENV GOARCH=$TARGETARCH
+RUN --mount=type=cache,id=konnectivity-go-modcache,target=/go/pkg/mod,ro \
+  --mount=type=cache,id=konnectivity-agent-go-cache-$TARGETARCH,target=/root/.cache/go-build \
+  --mount=type=tmpfs,target=/tmp \
+  --network=none \
+  go build \
+  -v -mod=readonly -trimpath -buildvcs=false \
+  -ldflags "-s -w" \
+  ./cmd/agent
+
+FROM $DEFAULT_BASEIMAGE AS final-amd64
+FROM $DEFAULT_BASEIMAGE AS final-arm64
+FROM $DEFAULT_BASEIMAGE AS final-arm
+FROM $RISCV_BASEIMAGE   AS final-riscv64
+# nobody:nobody
+USER 65534:65534
+
+FROM final-$TARGETARCH
+LABEL org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/kubernetes-sigs/apiserver-network-proxy"
+COPY --from=build /go/src/kubernetes-sigs/apiserver-network-proxy/agent /proxy-agent
+ENTRYPOINT ["/proxy-agent"]

--- a/images/apiserver-network-proxy-agent/v0.34.0-k0s.2/Dockerfile
+++ b/images/apiserver-network-proxy-agent/v0.34.0-k0s.2/Dockerfile
@@ -1,10 +1,14 @@
+# SPDX-FileCopyrightText: 2026 k0s authors
+# SPDX-License-Identifier: Apache-2.0
+
 ARG \
   VERSION=0.34.0 \
   HASH=f338b1db93558121252eec01113a9adcf542d2c23d6c63a092cf9d2ae95317ac \
-  DEFAULT_BASEIMAGE=gcr.io/distroless/static-debian12:nonroot@sha256:e8a4044e0b4ae4257efa45fc026c0bc30ad320d43bd4c1a7d5271bd241e386d0 \
-  RISCV_BASEIMAGE=ghcr.io/go-riscv/distroless/static-unstable:latest@sha256:0bd27d7ab1f1863abecdebe207870375364fddc1d0ae87179ef176403d04e27b
+  BUILDIMAGE=docker.io/library/golang:1.26.2-alpine3.23 \
+  DISTROLESS_BASEIMAGE=gcr.io/distroless/static-debian13:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39 \
+  WINDOWS_VERSION=
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.25.3-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM $BUILDIMAGE AS sources
 ENV CGO_ENABLED=0 GOTELEMETRY=off
 WORKDIR /go/src/kubernetes-sigs/apiserver-network-proxy
 
@@ -13,30 +17,38 @@ RUN --mount=type=cache,id=konnectivity-go-modcache,target=/go/pkg/mod \
   --mount=type=tmpfs,target=/tmp \
   set -e \
   && wget -qO /tmp/src.tar.gz https://github.com/kubernetes-sigs/apiserver-network-proxy/archive/refs/tags/v$VERSION.tar.gz \
-  && { printf '%s */tmp/src.tar.gz' "$HASH" | sha256sum -c -; } \
-  && tar xf /tmp/src.tar.gz --strip-components=1 \
-  && go mod download -x
+  && { echo $HASH /tmp/src.tar.gz | sha256sum -c -; } || { sha256sum /tmp/src.tar.gz; exit 1; } \
+  && tar xf /tmp/src.tar.gz --strip-components=1
+RUN go mod download
 
-ARG TARGETARCH
-ENV GOARCH=$TARGETARCH
-RUN --mount=type=cache,id=konnectivity-go-modcache,target=/go/pkg/mod,ro \
-  --mount=type=cache,id=konnectivity-agent-go-cache-$TARGETARCH,target=/root/.cache/go-build \
-  --mount=type=tmpfs,target=/tmp \
+
+FROM sources AS binary
+ARG TARGETOS TARGETARCH SOURCE_DATE_EPOCH
+ENV GOOS=$TARGETOS GOARCH=$TARGETARCH
+RUN --mount=type=cache,id=konnectivity-agent-go-cache-$TARGETOS-$TARGETARCH,target=/root/.cache/go-build \
   --network=none \
   go build \
-  -v -mod=readonly -trimpath -buildvcs=false \
-  -ldflags "-s -w" \
+  -mod=readonly -trimpath -buildvcs=false \
+  -o /out/proxy-agent \
+   -ldflags "-s -w" \
   ./cmd/agent
 
-FROM $DEFAULT_BASEIMAGE AS final-amd64
-FROM $DEFAULT_BASEIMAGE AS final-arm64
-FROM $DEFAULT_BASEIMAGE AS final-arm
-FROM $RISCV_BASEIMAGE   AS final-riscv64
-# nobody:nobody
-USER 65534:65534
 
-FROM final-$TARGETARCH
-LABEL org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/kubernetes-sigs/apiserver-network-proxy"
-COPY --from=build /go/src/kubernetes-sigs/apiserver-network-proxy/agent /proxy-agent
+FROM $DISTROLESS_BASEIMAGE AS final-linux
+COPY --from=binary /out/proxy-agent /
 ENTRYPOINT ["/proxy-agent"]
+
+
+FROM mcr.microsoft.com/windows/nanoserver:ltsc$WINDOWS_VERSION AS final-windows
+COPY --from=binary /out/proxy-agent /proxy-agent.exe
+ENTRYPOINT ["proxy-agent.exe"]
+
+
+FROM final-$TARGETOS
+ARG VERSION
+LABEL org.opencontainers.image.title="konnectivity-agent for k0s" \
+  org.opencontainers.image.vendor=k0sproject \
+  org.opencontainers.image.source=https://github.com/k0sproject/image-builder \
+  org.opencontainers.image.licenses=Apache-2.0 \
+  org.opencontainers.image.url=https://github.com/kubernetes-sigs/apiserver-network-proxy \
+  org.opencontainers.image.version="v$VERSION"

--- a/index-append.sh
+++ b/index-append.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+# SPDX-FileCopyrightText: 2026 k0s authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+if [ $# -eq 0 ] || [ "$1" = '-h' ] || [ "$1" = '--help' ] || { [ "$1" = -- ] && [ $# -eq 1 ]; }; then
+  echo 'Combine multi-platform OCI images. Use like so:'
+  echo
+  echo "  $0 [--] <output-dir> <archive-file-1> <archive-file-2> ..."
+  echo "  $0 < -h | --help >"
+  exit 0
+fi
+
+[ "$1" != -- ] || shift
+out=$1
+shift
+
+mkdir -p -- "$out"
+
+index='{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.index.v1+json", "manifests": []}'
+
+while [ $# -gt 0 ]; do
+  tar xf "$1" -C "$out" blobs/ index.json oci-layout
+
+  nextIndex="$out/index.json"
+  content=$(jq -r '.manifests[0] | "\(.mediaType) \(.digest)"' "$nextIndex")
+
+  case "${content%% *}" in
+  application/vnd.oci.image.index.v1+json)
+    content=${content#* }
+    nextIndex="$out/blobs/${content%%:*}/${content#*:}"
+    ;;
+  esac
+
+  index=$(IDX=$index jq '.manifests as $next | $ENV.IDX | fromjson | .manifests += $next' "$nextIndex")
+  rm -f -- "$nextIndex"
+  shift
+done
+
+sum=$(printf %s "$index" | sha256sum)
+sum=${sum%% *}
+
+[ -f "$out/blobs/sha256/$sum" ] || printf %s "$index" >"$out/blobs/sha256/$sum"
+IDX=$index SUM=$sum jq -n '($ENV.IDX | fromjson) as $idx | $idx | .manifests = [{mediaType: $idx.mediaType, digest: "sha256:\($ENV.SUM)", size: ($ENV.IDX | utf8bytelength)}]' >"$out/index.json"
+
+chmod 444 -- "$out/blobs/sha256/$sum"
+touch -r "$out/oci-layout" -- "$out/index.json" "$out/blobs/sha256/$sum"
+
+echo sha256:"$sum"


### PR DESCRIPTION
Previously, users couldn't simply add Windows nodes to k0s clusters when konnectivity was enabled (which is the default). The only real blocker was the missing konnectivity-agent container image.

Add Windows 2019, 2022, and 2025 variants to the konnectivity-agent image. This allows a single image tag to work across Linux and Windows without splitting up DaemonSets for each operating system just to select an OS-specific tag.

Bump Go to v1.26.2 and the Linux distroless base image to Debian 13, which now officially supports RISC-V, so the experimental RISC-V base image can be removed. With all Linux platforms now sharing the same base image, `TARGETARCH` is no longer needed for final stage selection. `TARGETOS` alone is enough to distinguish `final-linux` from the new `final-windows` stage, which uses the Nano Server base image, parameterized via the `WINDOWS_VERSION` build argument. The Windows executable itself is cross-compiled on the build architecture, just like its Linux counterparts.

Because BuildKit cannot produce a multi-platform image that not only targets different OS and architecture combinations, but also different OS versions, the original multi-arch variant and each Windows variant (2019, 2022, 2025) are built in separate steps and saved in OCI image archives. `The index-append.sh` helper script then merges the archives together into a combined image archive, which is then pushed via ORAS. This keeps all image manipulation local. No need for intermediate pushes to some registry.

The bespoke `index-append.sh` helper exists because none of the off-the-shelf tools handle this combination: Both ORAS and crane require remote registries for these operations, though regclient's regctl can merge the images locally. However, it produces a nested index of indexes rather than flattening the Linux multi-platform index into the top-level manifest, which is just weird, and not guaranteed to be supported at all by container runtimes.

This way, there's just a single tag for all the different image variants, which makes things much easier for k0s.