### PR TITLE
Add Traefik v3.7.7

### DIFF
--- a/images/traefik/v3.7.7-k0s.0/Dockerfile
+++ b/images/traefik/v3.7.7-k0s.0/Dockerfile
@@ -1,0 +1,59 @@
+ARG \
+  VERSION=3.7.6 \
+  HASH=2f87a5d4d2e7b732aa831b8666cdb786008df7544c385881d016189756aa148a \
+  BUILDIMAGE=docker.io/library/golang:1.26.4-alpine3.24@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 \
+  DISTROLESS_BASEIMAGE=gcr.io/distroless/static-debian13:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240 \
+  HPC_BASEIMAGE=mcr.microsoft.com/oss/v2/kubernetes/windows-host-process-containers-base-image:2.0.0@sha256:85d91507422525f89358038d0534e45375b19f360ffadaeb0119f7f86a294773
+
+FROM --platform=$BUILDPLATFORM $BUILDIMAGE AS sources
+ENV GOTOOLCHAIN=local GOTELEMETRY=off
+WORKDIR /go/src/traefik
+ARG VERSION HASH
+RUN --mount=type=tmpfs,target=/tmp \
+  set -euo pipefail \
+  && wget -qO /tmp/sources.tar.gz https://github.com/traefik/traefik/archive/refs/tags/v$VERSION.tar.gz \
+  && { echo $HASH /tmp/sources.tar.gz | sha256sum -c -; } || { sha256sum /tmp/sources.tar.gz; exit 1; } \
+  && tar xf /tmp/sources.tar.gz --strip-components=1
+RUN go mod download
+
+
+FROM sources AS builder
+RUN apk add --no-cache make
+
+
+FROM builder AS binary
+ARG TARGETOS TARGETARCH SOURCE_DATE_EPOCH
+RUN --mount=type=cache,id=calico-gocache-$TARGETOS-$TARGETARCH,target=/root/.cache/go-build \
+  --network=none \
+  `# https://github.com/traefik/traefik/blob/v3.7.6/Makefile#L59` \
+  && make --touch generate-webui \
+  && make binary \
+    GOOS=$TARGETOS \
+    GOARCH=$TARGETARCH \
+    `# https://github.com/traefik/traefik/pull/13009` \
+    'FLAGS[*]=-mod=readonly -trimpath -buildvcs=false' \
+    `# https://github.com/traefik/traefik/blob/v3.7.6/Makefile#L11` \
+    DATE=$(date -u -d @$SOURCE_DATE_EPOCH '+%Y-%m-%d_%I:%M:%S%p') \
+  && mkdir /out \
+  && mv -v dist/$TARGETOS/$TARGETARCH/traefik /out/
+
+
+FROM $DISTROLESS_BASEIMAGE AS final-linux
+COPY --from=binary /out/traefik /traefik
+ENTRYPOINT ["/traefik"]
+
+
+FROM $HPC_BASEIMAGE AS final-windows
+COPY --from=binary /out/traefik /traefik.exe
+ENTRYPOINT ["traefik.exe"]
+
+
+FROM final-$TARGETOS
+
+ARG VERSION
+LABEL org.opencontainers.image.title="Traefik for k0s" \
+  org.opencontainers.image.vendor=k0sproject \
+  org.opencontainers.image.source=https://github.com/k0sproject/image-builder \
+  org.opencontainers.image.licenses=Apache-2.0 \
+  org.opencontainers.image.url=https://traefik.io \
+  org.opencontainers.image.version="v$VERSION"

--- a/images/traefik/v3.7.7-k0s.0/Dockerfile
+++ b/images/traefik/v3.7.7-k0s.0/Dockerfile
@@ -1,8 +1,8 @@
 ARG \
-  VERSION=3.7.6 \
-  HASH=2f87a5d4d2e7b732aa831b8666cdb786008df7544c385881d016189756aa148a \
+  VERSION=3.7.7 \
+  HASH=721ecfaac0ab1760f8127aaba8a09606b3229b5d5c7c422c98c4e5b07d9301d0 \
   BUILDIMAGE=docker.io/library/golang:1.26.4-alpine3.24@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 \
-  DISTROLESS_BASEIMAGE=gcr.io/distroless/static-debian13:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240 \
+  DISTROLESS_BASEIMAGE=gcr.io/distroless/static-debian13:nonroot@sha256:d29e660cc75a5b6b1334e03c5c81ccf9bc0884a002c6000dbf0fb96034814478 \
   HPC_BASEIMAGE=mcr.microsoft.com/oss/v2/kubernetes/windows-host-process-containers-base-image:2.0.0@sha256:85d91507422525f89358038d0534e45375b19f360ffadaeb0119f7f86a294773
 
 FROM --platform=$BUILDPLATFORM $BUILDIMAGE AS sources
@@ -25,14 +25,13 @@ FROM builder AS binary
 ARG TARGETOS TARGETARCH SOURCE_DATE_EPOCH
 RUN --mount=type=cache,id=calico-gocache-$TARGETOS-$TARGETARCH,target=/root/.cache/go-build \
   --network=none \
-  `# https://github.com/traefik/traefik/blob/v3.7.6/Makefile#L59` \
+  `# https://github.com/traefik/traefik/blob/v3.7.7/Makefile#L59` \
   && make --touch generate-webui \
   && make binary \
     GOOS=$TARGETOS \
     GOARCH=$TARGETARCH \
-    `# https://github.com/traefik/traefik/pull/13009` \
-    'FLAGS[*]=-mod=readonly -trimpath -buildvcs=false' \
-    `# https://github.com/traefik/traefik/blob/v3.7.6/Makefile#L11` \
+    FLAGS='-mod=readonly -trimpath -buildvcs=false' \
+    `# https://github.com/traefik/traefik/blob/v3.7.7/Makefile#L11` \
     DATE=$(date -u -d @$SOURCE_DATE_EPOCH '+%Y-%m-%d_%I:%M:%S%p') \
   && mkdir /out \
   && mv -v dist/$TARGETOS/$TARGETARCH/traefik /out/


### PR DESCRIPTION
https://github.com/traefik/traefik/releases/tag/v3.7.7

Also bump the distroless base image and remove a workaround which has been merged upstream.