### PR TITLE
Bump pushgateway-ttl builder to Go 1.26.5

### DIFF
--- a/images/pushgateway-ttl/1.4.0-k0s.2/Dockerfile
+++ b/images/pushgateway-ttl/1.4.0-k0s.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.26.2-alpine3.23 AS builder
+FROM docker.io/library/golang:1.26.5-alpine3.23 AS builder
 
 RUN apk add git make curl
 


### PR DESCRIPTION
The builder was pinned to Go 1.26.2