### PR TITLE
Bump apiserver-network-proxy-agent Go and deps to fix CVEs

### DIFF
--- a/images/apiserver-network-proxy-agent/v0.36.0-k0s.1/Dockerfile
+++ b/images/apiserver-network-proxy-agent/v0.36.0-k0s.1/Dockerfile
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 k0s authors
+# SPDX-License-Identifier: Apache-2.0
+
+ARG \
+  VERSION=0.36.0 \
+  HASH=28e7766158efd496cef5d75155b38a8883a59aff8282bef65a5a7e5e6e6f8481 \
+  BUILDIMAGE=docker.io/library/golang:1.26.4-alpine3.23 \
+  DISTROLESS_BASEIMAGE=gcr.io/distroless/static-debian13:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240 \
+  WINDOWS_VERSION=
+
+FROM --platform=$BUILDPLATFORM $BUILDIMAGE AS sources
+ENV CGO_ENABLED=0 GOTELEMETRY=off
+WORKDIR /go/src/kubernetes-sigs/apiserver-network-proxy
+
+ARG VERSION HASH
+RUN --mount=type=cache,id=konnectivity-go-modcache,target=/go/pkg/mod \
+  --mount=type=tmpfs,target=/tmp \
+  set -e \
+  && wget -qO /tmp/src.tar.gz https://github.com/kubernetes-sigs/apiserver-network-proxy/archive/refs/tags/v$VERSION.tar.gz \
+  && { echo $HASH /tmp/src.tar.gz | sha256sum -c -; } || { sha256sum /tmp/src.tar.gz; exit 1; } \
+  && tar xf /tmp/src.tar.gz --strip-components=1
+RUN go mod download
+
+
+FROM sources AS binary
+ARG TARGETOS TARGETARCH SOURCE_DATE_EPOCH
+ENV GOOS=$TARGETOS GOARCH=$TARGETARCH
+RUN --mount=type=cache,id=konnectivity-agent-go-cache-$TARGETOS-$TARGETARCH,target=/root/.cache/go-build \
+  --network=none \
+  go build \
+  -mod=readonly -trimpath -buildvcs=false \
+  -o /out/proxy-agent \
+   -ldflags "-s -w" \
+  ./cmd/agent
+
+
+FROM $DISTROLESS_BASEIMAGE AS final-linux
+COPY --from=binary /out/proxy-agent /
+ENTRYPOINT ["/proxy-agent"]
+
+
+FROM mcr.microsoft.com/windows/nanoserver:ltsc$WINDOWS_VERSION AS final-windows
+COPY --from=binary /out/proxy-agent /proxy-agent.exe
+ENTRYPOINT ["proxy-agent.exe"]
+
+
+FROM final-$TARGETOS
+ARG VERSION
+LABEL org.opencontainers.image.title="konnectivity-agent for k0s" \
+  org.opencontainers.image.vendor=k0sproject \
+  org.opencontainers.image.source=https://github.com/k0sproject/image-builder \
+  org.opencontainers.image.licenses=Apache-2.0 \
+  org.opencontainers.image.url=https://github.com/kubernetes-sigs/apiserver-network-proxy \
+  org.opencontainers.image.version="v$VERSION"

--- a/images/apiserver-network-proxy-agent/v0.36.0-k0s.1/Dockerfile
+++ b/images/apiserver-network-proxy-agent/v0.36.0-k0s.1/Dockerfile
@@ -4,7 +4,7 @@
 ARG \
   VERSION=0.36.0 \
   HASH=28e7766158efd496cef5d75155b38a8883a59aff8282bef65a5a7e5e6e6f8481 \
-  BUILDIMAGE=docker.io/library/golang:1.26.4-alpine3.23 \
+  BUILDIMAGE=docker.io/library/golang:1.26.6-alpine3.23 \
   DISTROLESS_BASEIMAGE=gcr.io/distroless/static-debian13:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240 \
   WINDOWS_VERSION=
 
@@ -19,6 +19,12 @@ RUN --mount=type=cache,id=konnectivity-go-modcache,target=/go/pkg/mod \
   && wget -qO /tmp/src.tar.gz https://github.com/kubernetes-sigs/apiserver-network-proxy/archive/refs/tags/v$VERSION.tar.gz \
   && { echo $HASH /tmp/src.tar.gz | sha256sum -c -; } || { sha256sum /tmp/src.tar.gz; exit 1; } \
   && tar xf /tmp/src.tar.gz --strip-components=1
+RUN --mount=type=cache,id=konnectivity-go-modcache,target=/go/pkg/mod \
+  go get \
+  golang.org/x/net@v0.56.0 \
+  golang.org/x/text@v0.39.0 \
+  google.golang.org/grpc@v1.82.1 \
+  && go mod tidy
 RUN go mod download
 
 

--- a/images/apiserver-network-proxy-agent/v0.36.0-k0s.1/Dockerfile
+++ b/images/apiserver-network-proxy-agent/v0.36.0-k0s.1/Dockerfile
@@ -19,11 +19,27 @@ RUN --mount=type=cache,id=konnectivity-go-modcache,target=/go/pkg/mod \
   && wget -qO /tmp/src.tar.gz https://github.com/kubernetes-sigs/apiserver-network-proxy/archive/refs/tags/v$VERSION.tar.gz \
   && { echo $HASH /tmp/src.tar.gz | sha256sum -c -; } || { sha256sum /tmp/src.tar.gz; exit 1; } \
   && tar xf /tmp/src.tar.gz --strip-components=1
+ARG XNET_VERSION=v0.56.0 XTEXT_VERSION=v0.39.0 GRPC_VERSION=v1.82.1
 RUN --mount=type=cache,id=konnectivity-go-modcache,target=/go/pkg/mod \
-  go get \
-  golang.org/x/net@v0.56.0 \
-  golang.org/x/text@v0.39.0 \
-  google.golang.org/grpc@v1.82.1 \
+  set -eu \
+  && for spec in \
+    "golang.org/x/net $XNET_VERSION" \
+    "golang.org/x/text $XTEXT_VERSION" \
+    "google.golang.org/grpc $GRPC_VERSION" \
+  ; do \
+    pkg=$(echo "$spec" | cut -d' ' -f1); \
+    want=$(echo "$spec" | cut -d' ' -f2); \
+    have=$(go list -m -f '{{.Version}}' "$pkg"); \
+    newer=$(printf '%s\n%s\n' "${have#v}" "${want#v}" | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1); \
+    if [ "$newer" = "${have#v}" ] && [ "$have" != "$want" ]; then \
+      echo "ERROR: $pkg is already $have (>= $want) -- remove this pin from the Dockerfile" >&2; \
+      exit 1; \
+    fi; \
+  done \
+  && go get \
+  golang.org/x/net@$XNET_VERSION \
+  golang.org/x/text@$XTEXT_VERSION \
+  google.golang.org/grpc@$GRPC_VERSION \
   && go mod tidy
 RUN go mod download
 


### PR DESCRIPTION
Bump the Go build image to 1.26.6 and pull patched module dependencies, since upstream v0.36.0 hasn't bumped them yet.

Verified with trivy: 0 vulnerabilities against the rebuilt image.
    
Fixes:
- Go stdlib: CVE-2026-39821, CVE-2026-39822, CVE-2026-46600,
  CVE-2026-42505, CVE-2026-33818, CVE-2026-56853, CVE-2026-56858,
  CVE-2026-56859, CVE-2026-56860, CVE-2026-56862
  (golang:1.26.4-alpine3.23 -> golang:1.26.6-alpine3.23)
- golang.org/x/net: CVE-2026-46600 (v0.55.0 -> v0.56.0)
- golang.org/x/text: CVE-2026-56852 (v0.37.0 -> v0.39.0)
- google.golang.org/grpc: GHSA-hrxh-6v49-42gf (v1.81.1 -> v1.82.1)
