### PR TITLE
calico-kube-controllers CVE fixes

### DIFF
--- a/images/calico-kube-controllers/v3.32.1-3/Dockerfile
+++ b/images/calico-kube-controllers/v3.32.1-3/Dockerfile
@@ -1,0 +1,82 @@
+# https://github.com/projectcalico/calico/blob/v3.32.1/kube-controllers/Dockerfile
+
+ARG \
+  VERSION=3.32.1 \
+  HASH=ee4699f5ffff98ff53de89bd5a36e8b647f671a6b4d707638990f1097f76e2cf \
+  GIT_REVISION=0ca9d1b93644778cafdf1812f3dda02ac0c361e8
+
+# Dependency overrides for advisories still open in calico v3.32.1:
+# GO-2026-5970 (x/text), GO-2026-6061 (grpc), GO-2026-5158 (otel) and
+# GO-2026-5841 (klauspost/compress). Raising them requires `go mod tidy`, which
+# also nudges a handful of unrelated transitive dependencies, so drop each
+# override again once upstream picks the version up.
+ARG \
+  XTEXT_VERSION=v0.39.0 \
+  GRPC_VERSION=v1.82.1 \
+  OTEL_VERSION=v1.44.0 \
+  COMPRESS_VERSION=v1.18.7
+
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-alpine3.23 AS builder
+
+ARG VERSION HASH
+WORKDIR /go/src/calico
+RUN --mount=type=tmpfs,target=/tmp \
+  set -euo pipefail \
+  && wget -qO /tmp/sources.tar.gz https://github.com/projectcalico/calico/archive/refs/tags/v$VERSION.tar.gz \
+  && { echo $HASH /tmp/sources.tar.gz | sha256sum -c -; } \
+  && tar xf /tmp/sources.tar.gz --strip-components=1 \
+  && find . -type f -exec stat -c '%Y' {} \; | sort -n -u | tail -1 >/tmp/source-date-epoch \
+  && read -r SOURCE_DATE_EPOCH </tmp/source-date-epoch \
+  && touch -d "@$SOURCE_DATE_EPOCH" /tmp/source-date-epoch \
+  && mv -T /tmp/source-date-epoch .source-date-epoch
+
+ARG XTEXT_VERSION GRPC_VERSION OTEL_VERSION COMPRESS_VERSION
+RUN set -eu \
+  && go mod edit \
+    -require=golang.org/x/text@$XTEXT_VERSION \
+    -require=google.golang.org/grpc@$GRPC_VERSION \
+    -require=go.opentelemetry.io/otel@$OTEL_VERSION \
+    -require=github.com/klauspost/compress@$COMPRESS_VERSION \
+  && go mod tidy \
+  && for want in \
+    "golang.org/x/text $XTEXT_VERSION" \
+    "google.golang.org/grpc $GRPC_VERSION" \
+    "go.opentelemetry.io/otel $OTEL_VERSION" \
+    "github.com/klauspost/compress $COMPRESS_VERSION"; \
+  do \
+    got=$(go list -m "${want% *}"); \
+    [ "$got" = "$want" ] || { echo "dependency override lost: got '$got', want '$want'"; exit 1; }; \
+  done \
+  && go mod download
+
+ARG TARGETARCH GIT_REVISION
+RUN --mount=type=cache,id=calico-gocache-$TARGETARCH,target=/root/.cache/go-build \
+  --network=none \
+  read -r SOURCE_DATE_EPOCH <.source-date-epoch \
+  && export SOURCE_DATE_EPOCH \
+  && export GOARCH=$TARGETARCH \
+  && export CGO_ENABLED=0 \
+  && LDFLAGS='-s -w' \
+  && LDFLAGS="$LDFLAGS -X main.VERSION=v$VERSION" \
+  && LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/pkg/buildinfo.Version=v$VERSION" \
+  && `# https://github.com/projectcalico/calico/blob/v3.32.1/lib.Makefile#L229` \
+  && `# https://github.com/projectcalico/calico/blob/v3.32.1/lib.Makefile#L237-L238` \
+  && LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/pkg/buildinfo.BuildDate=$(date -u -d @$SOURCE_DATE_EPOCH +'%FT%T%z')" \
+  && LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/pkg/buildinfo.GitRevision=$GIT_REVISION" \
+  && go build \
+    -mod=readonly -trimpath -buildvcs=false \
+    -ldflags "$LDFLAGS" \
+    -o /out/usr/bin/ \
+    ./kube-controllers/cmd/kube-controllers \
+    ./kube-controllers/cmd/check-status \
+    ./kube-controllers/cmd/wrapper
+
+RUN mkdir /out/licenses && cp -a LICENSE.md /out/licenses/
+RUN mkdir /out/status && touch /out/status/status.json && chown 999 /out/status/status.json
+
+FROM scratch
+LABEL org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/projectcalico/calico"
+COPY --from=builder /out/ /
+USER 999
+ENTRYPOINT ["/usr/bin/wrapper", "/usr/bin/kube-controllers"]

--- a/images/calico-kube-controllers/v3.32.1-3/Dockerfile
+++ b/images/calico-kube-controllers/v3.32.1-3/Dockerfile
@@ -6,17 +6,19 @@ ARG \
   GIT_REVISION=0ca9d1b93644778cafdf1812f3dda02ac0c361e8
 
 # Dependency overrides for advisories still open in calico v3.32.1:
-# GO-2026-5970 (x/text), GO-2026-6061 (grpc), GO-2026-5158 (otel) and
-# GO-2026-5841 (klauspost/compress). Raising them requires `go mod tidy`, which
-# also nudges a handful of unrelated transitive dependencies, so drop each
-# override again once upstream picks the version up.
+# GO-2026-5970 (x/text), GO-2026-6061 (grpc), GO-2026-5158 (otel),
+# GO-2026-5841 (klauspost/compress) and GHSA-gcjh-h69q-9w9g (cel-go).
+# Raising them requires `go mod tidy`, which also nudges a handful of
+# unrelated transitive dependencies, so drop each override again once
+# upstream picks the version up.
 ARG \
   XTEXT_VERSION=v0.39.0 \
   GRPC_VERSION=v1.82.1 \
   OTEL_VERSION=v1.44.0 \
-  COMPRESS_VERSION=v1.18.7
+  COMPRESS_VERSION=v1.18.7 \
+  CELGO_VERSION=v0.29.0
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-alpine3.23 AS builder
 
 ARG VERSION HASH
 WORKDIR /go/src/calico
@@ -30,19 +32,21 @@ RUN --mount=type=tmpfs,target=/tmp \
   && touch -d "@$SOURCE_DATE_EPOCH" /tmp/source-date-epoch \
   && mv -T /tmp/source-date-epoch .source-date-epoch
 
-ARG XTEXT_VERSION GRPC_VERSION OTEL_VERSION COMPRESS_VERSION
+ARG XTEXT_VERSION GRPC_VERSION OTEL_VERSION COMPRESS_VERSION CELGO_VERSION
 RUN set -eu \
   && go mod edit \
     -require=golang.org/x/text@$XTEXT_VERSION \
     -require=google.golang.org/grpc@$GRPC_VERSION \
     -require=go.opentelemetry.io/otel@$OTEL_VERSION \
     -require=github.com/klauspost/compress@$COMPRESS_VERSION \
+    -require=github.com/google/cel-go@$CELGO_VERSION \
   && go mod tidy \
   && for want in \
     "golang.org/x/text $XTEXT_VERSION" \
     "google.golang.org/grpc $GRPC_VERSION" \
     "go.opentelemetry.io/otel $OTEL_VERSION" \
-    "github.com/klauspost/compress $COMPRESS_VERSION"; \
+    "github.com/klauspost/compress $COMPRESS_VERSION" \
+    "github.com/google/cel-go $CELGO_VERSION"; \
   do \
     got=$(go list -m "${want% *}"); \
     [ "$got" = "$want" ] || { echo "dependency override lost: got '$got', want '$want'"; exit 1; }; \


### PR DESCRIPTION
Bump the Go build image to 1.26.6 and add a cel-go dependency
override, since upstream v3.32.1 hasn't picked it up yet.

Verified with trivy: 0 vulnerabilities against the rebuilt image.
    
Fixes:
- Go stdlib: CVE-2026-39821, CVE-2026-46600, CVE-2026-33818,
  CVE-2026-56853, CVE-2026-56858, CVE-2026-56859, CVE-2026-56860,
  CVE-2026-56862 (golang:1.26.5-alpine3.23 -> golang:1.26.6-alpine3.23,
  affects check-status, kube-controllers, wrapper)
- github.com/google/cel-go: GHSA-gcjh-h69q-9w9g (v0.26.0 -> v0.29.0,
  affects kube-controllers)
