### PR TITLE
Bump calico-node Go and deps to fix CVEs

### DIFF
--- a/images/calico-node/v3.32.1-3/Dockerfile
+++ b/images/calico-node/v3.32.1-3/Dockerfile
@@ -1,0 +1,215 @@
+# https://github.com/projectcalico/calico/blob/v3.32.1/node/Dockerfile.amd64
+
+ARG \
+  VERSION=3.32.1 \
+  HASH=ee4699f5ffff98ff53de89bd5a36e8b647f671a6b4d707638990f1097f76e2cf \
+  GIT_REVISION=0ca9d1b93644778cafdf1812f3dda02ac0c361e8 \
+  IPSET_VERSION=7.23 \
+  IPSET_HASH=5a43c790abf157a55db5a9a22cb5f28a225f5c7969beda81566a2259aa82c9d852979eb805b11b4347f47c6a0c2cc4de6f14e4733bee5b562844422a45fb9dab \
+  # https://github.com/projectcalico/calico/blob/v3.32.1/metadata.mk#L42-43
+  BIRD_COMMIT=9111ec3c3ff3e769727a5940d3d829a0be8b5201 \
+  BIRD_HASH=5aaf11e2f0ba3c44cdf27746c0b5da631befd67636579ff5e2ac65b144bee0b3 \
+  ALPINE_IMAGE=docker.io/library/alpine:3.23.5 \
+  BUILDER_IMAGE=docker.io/library/golang:1.26.5-alpine3.23 \
+  IPTABLES_VERSION=1.8.13 \
+  IPTABLES_HASH=1afcd33da9e8f913ace6a2126788162e207e26f5d5e29c6573c0e581ffc58b99
+
+# Dependency overrides for advisories still open in calico v3.32.1:
+# GO-2026-5970 (x/text), GO-2026-6061 (grpc), GO-2026-5158 (otel) and
+# GO-2026-5841 (klauspost/compress). Raising them requires `go mod tidy`, which
+# also nudges a handful of unrelated transitive dependencies, so drop each
+# override again once upstream picks the version up.
+ARG \
+  XTEXT_VERSION=v0.39.0 \
+  GRPC_VERSION=v1.82.1 \
+  OTEL_VERSION=v1.44.0 \
+  COMPRESS_VERSION=v1.18.7
+
+FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS builder
+
+ARG VERSION HASH
+WORKDIR /go/src/calico
+RUN --mount=type=tmpfs,target=/tmp \
+  set -euo pipefail \
+  && wget -qO /tmp/sources.tar.gz https://github.com/projectcalico/calico/archive/refs/tags/v$VERSION.tar.gz \
+  && { echo $HASH /tmp/sources.tar.gz | sha256sum -c -; } \
+  && tar xf /tmp/sources.tar.gz --strip-components=1 \
+  && find . -type f -exec stat -c '%Y' {} \; | sort -n -u | tail -1 >/tmp/source-date-epoch \
+  && read -r SOURCE_DATE_EPOCH </tmp/source-date-epoch \
+  && touch -d "@$SOURCE_DATE_EPOCH" /tmp/source-date-epoch \
+  && mv -T /tmp/source-date-epoch .source-date-epoch
+
+ARG XTEXT_VERSION GRPC_VERSION OTEL_VERSION COMPRESS_VERSION
+RUN set -eu \
+  && go mod edit \
+    -require=golang.org/x/text@$XTEXT_VERSION \
+    -require=google.golang.org/grpc@$GRPC_VERSION \
+    -require=go.opentelemetry.io/otel@$OTEL_VERSION \
+    -require=github.com/klauspost/compress@$COMPRESS_VERSION \
+  && go mod tidy \
+  && for want in \
+    "golang.org/x/text $XTEXT_VERSION" \
+    "google.golang.org/grpc $GRPC_VERSION" \
+    "go.opentelemetry.io/otel $OTEL_VERSION" \
+    "github.com/klauspost/compress $COMPRESS_VERSION"; \
+  do \
+    got=$(go list -m "${want% *}"); \
+    [ "$got" = "$want" ] || { echo "dependency override lost: got '$got', want '$want'"; exit 1; }; \
+  done \
+  && go mod download
+
+ARG TARGETARCH GIT_REVISION
+RUN --mount=type=cache,id=calico-gocache-$TARGETARCH,target=/root/.cache/go-build \
+  --network=none \
+  read -r SOURCE_DATE_EPOCH <.source-date-epoch \
+  && export SOURCE_DATE_EPOCH \
+  && export GOARCH=$TARGETARCH \
+  && export CGO_ENABLED=0 \
+  && LDFLAGS='-s -w' \
+  && LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/pkg/buildinfo.Version=v$VERSION" \
+  && `# https://github.com/projectcalico/calico/blob/v3.32.1/lib.Makefile#L229-L233` \
+  && LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/pkg/buildinfo.BuildDate=$(date -u -d @$SOURCE_DATE_EPOCH +'%FT%T%z')" \
+  && LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/pkg/buildinfo.GitRevision=$GIT_REVISION" \
+  && go build \
+    -mod=readonly -trimpath -buildvcs=false \
+    -ldflags "$LDFLAGS" \
+    -o . \
+    ./node/cmd/calico-node ./node/cmd/mountns \
+  && chmod u+s mountns
+
+FROM $ALPINE_IMAGE AS ipset
+RUN apk add --no-cache \
+  build-base pkgconf curl \
+  libmnl-dev libmnl-static
+
+ARG IPSET_VERSION IPSET_HASH
+RUN curl -sSLo ipset.tar.bz2 "http://ipset.netfilter.org/ipset-$IPSET_VERSION.tar.bz2" \
+  && { echo $IPSET_HASH ipset.tar.bz2 | sha512sum -c -; } \
+  && mkdir -p /src/ipset && tar xf "ipset.tar.bz2" --strip-components=1 -C /src/ipset \
+  && rm -- "ipset.tar.bz2"
+
+WORKDIR /src/ipset
+RUN printf '#!/usr/bin/env sh\nexec cc -static "$@"\n' >/src/cc-static && chmod +x /src/cc-static
+RUN CC=/src/cc-static CFLAGS=-static LDFLAGS=-static ./configure --enable-static --disable-shared --with-kmod=no
+RUN make && strip src/ipset
+RUN make install
+# Just a sanity check that it's not segfaulting
+RUN ipset -h
+
+
+FROM --platform=$BUILDPLATFORM $ALPINE_IMAGE AS bird-sources
+ARG BIRD_COMMIT BIRD_HASH
+WORKDIR /bird
+RUN --mount=type=tmpfs,target=/tmp \
+  wget -qO /tmp/sources.tar.gz https://github.com/projectcalico/bird/archive/$BIRD_COMMIT.tar.gz \
+  && sha256sum -b /tmp/sources.tar.gz \
+  && { echo $BIRD_HASH /tmp/sources.tar.gz | sha256sum -c -; } \
+  && tar xf /tmp/sources.tar.gz --strip-components=1
+
+
+FROM $ALPINE_IMAGE AS bird
+RUN apk add --no-cache gcc musl-dev make autoconf flex bison linux-headers
+RUN --mount=from=bird-sources,source=/bird,target=/run/stage/bird,ro \
+  --mount=type=tmpfs,target=/bird \
+  --network=none \
+  cp -a /run/stage/bird / \
+  && cd /bird \
+  && export ARCH=$(uname -m) \
+  && export MAKEFLAGS='-j -O' \
+  && DIST=dist OBJ=obj sh -x ./create_binaries.sh \
+  && find dist/ -type f -mindepth 2 -maxdepth 2 -exec strip '{}' ';' \
+  && mkdir /dist \
+  && find dist/ -type f -mindepth 2 -maxdepth 2 -exec mv '{}' /dist ';'
+
+
+# Build iptables
+FROM $ALPINE_IMAGE AS iptables
+ARG IPTABLES_VERSION IPTABLES_HASH
+
+RUN apk add build-base curl pkgconf \
+	linux-headers \
+	libmnl-dev libmnl-static \
+	libnftnl-dev
+
+RUN curl --proto '=https' --tlsv1.2 -L https://www.netfilter.org/projects/iptables/files/iptables-$IPTABLES_VERSION.tar.xz -o /tmp/iptables.tar.xz \
+  && { echo $IPTABLES_HASH /tmp/iptables.tar.xz | sha256sum -c -; } \
+	&& tar -C / -Jx -f /tmp/iptables.tar.xz
+
+ARG TARGET_OS
+# -D__UAPI_DEF_ETHHDR is required to build on musl.
+# If this CFLAG isn't defined, itpables will define it in include/xtables.h
+# and will have a conflict with musl, which defines it in
+# /usr/include/netinet/if_ether.h
+RUN cd /iptables-$IPTABLES_VERSION && \
+  CFLAGS="-Os -D__UAPI_DEF_ETHHDR=0" ./configure --sysconfdir=/etc --enable-static --disable-shared --without-kernel --disable-devel
+
+RUN make -j$(nproc) -C /iptables-$IPTABLES_VERSION LDFLAGS=-all-static
+RUN make -j$(nproc) -C /iptables-$IPTABLES_VERSION install
+
+RUN strip /usr/local/sbin/xtables-legacy-multi
+RUN strip /usr/local/sbin/xtables-nft-multi
+RUN scanelf -Rn /usr/local && file /usr/local/sbin/*
+
+FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS iptables-wrapper
+RUN apk add --no-cache patch make
+
+ARG IPTABLES_WRAPPER_VERSION=06cad2ec6cb5ed0945b383fb185424c0a67f55eb
+ARG IPTABLES_WRAPPER_HASH=fde9ccd22b337fd297180cd21938c0a82030187fc29aabb6800472295d62752a
+
+WORKDIR /go/src/iptables-wrapper
+RUN --mount=type=tmpfs,target=/tmp \
+  wget -qO /tmp/sources.tar.gz https://github.com/kubernetes-sigs/iptables-wrappers/archive/$IPTABLES_WRAPPER_VERSION.tar.gz \
+  && { echo $IPTABLES_WRAPPER_HASH /tmp/sources.tar.gz | sha256sum -c -; } \
+  && tar xf /tmp/sources.tar.gz --strip-components=1
+RUN go mod download
+
+ARG TARGETARCH
+RUN --mount=source=files,target=/run/stage/files,ro \
+  --mount=type=tmpfs,target=/go/iptables-wrapper/bin \
+  --mount=type=cache,id=calico-gocache-$TARGETARCH,target=/root/.cache/go-build \
+  --network=none \
+  set -euo pipefail \
+  && patch </run/stage/files/iptables-wrapper.patch \
+  && GOARCH="$TARGETARCH" make build \
+  && mv bin/iptables-wrapper .
+
+# Build the image based on alpine
+FROM $ALPINE_IMAGE
+LABEL org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/projectcalico/calico"
+ARG TARGETARCH
+
+RUN apk add --no-cache bash iputils iproute2 conntrack-tools runit ca-certificates
+
+# Copy the calico-node binary from the builder image
+COPY --from=builder /go/src/calico/calico-node /usr/bin/calico-node
+COPY --from=builder /go/src/calico/mountns /usr/bin/mountns
+
+COPY --from=ipset /usr/local/sbin/ipset /usr/sbin/ipset
+COPY --from=ipset /src/ipset/ChangeLog /usr/share/doc/ipset/ChangeLog
+
+# Copy the config etc filesystem from builder
+COPY --from=builder /go/src/calico/node/filesystem/ /
+COPY --from=builder /go/src/calico/confd/etc/ /etc/
+
+# Change permissions to make confd templates and output available in /etc/calico
+# to all container users.
+RUN chgrp -R 0 /etc/calico && \
+    chmod -R g=u /etc/calico
+
+COPY --from=bird /dist/* /bin/
+
+# Copy iptables and wrappers
+COPY --from=iptables \
+  /usr/local/sbin/xtables-* \
+  /usr/local/sbin/iptables* \
+  /usr/local/sbin/ip6tables* \
+  /sbin/
+RUN --mount=from=iptables-wrapper,source=/go/src/iptables-wrapper,target=/run/stage/iptables-wrapper,ro \
+  cp -a /run/stage/iptables-wrapper/iptables-wrapper-installer.sh /run/stage/iptables-wrapper/iptables-wrapper / \
+  && /iptables-wrapper-installer.sh
+
+RUN echo "hosts: files dns" > /etc/nsswitch.conf
+
+ENV SVDIR=/etc/service/enabled
+CMD ["start_runit"]

--- a/images/calico-node/v3.32.1-3/Dockerfile
+++ b/images/calico-node/v3.32.1-3/Dockerfile
@@ -10,20 +10,24 @@ ARG \
   BIRD_COMMIT=9111ec3c3ff3e769727a5940d3d829a0be8b5201 \
   BIRD_HASH=5aaf11e2f0ba3c44cdf27746c0b5da631befd67636579ff5e2ac65b144bee0b3 \
   ALPINE_IMAGE=docker.io/library/alpine:3.23.5 \
-  BUILDER_IMAGE=docker.io/library/golang:1.26.5-alpine3.23 \
+  BUILDER_IMAGE=docker.io/library/golang:1.26.6-alpine3.23 \
   IPTABLES_VERSION=1.8.13 \
   IPTABLES_HASH=1afcd33da9e8f913ace6a2126788162e207e26f5d5e29c6573c0e581ffc58b99
 
 # Dependency overrides for advisories still open in calico v3.32.1:
-# GO-2026-5970 (x/text), GO-2026-6061 (grpc), GO-2026-5158 (otel) and
-# GO-2026-5841 (klauspost/compress). Raising them requires `go mod tidy`, which
-# also nudges a handful of unrelated transitive dependencies, so drop each
-# override again once upstream picks the version up.
+# GO-2026-5970 (x/text), GO-2026-6061 (grpc), GO-2026-5158 (otel),
+# GO-2026-5841 (klauspost/compress), GHSA-gcjh-h69q-9w9g (cel-go) and
+# CVE-2026-54332/CVE-2026-54345 (gopacket). Raising them requires
+# `go mod tidy`, which also nudges a handful of unrelated transitive
+# dependencies, so drop each override again once upstream picks the
+# version up.
 ARG \
   XTEXT_VERSION=v0.39.0 \
   GRPC_VERSION=v1.82.1 \
   OTEL_VERSION=v1.44.0 \
-  COMPRESS_VERSION=v1.18.7
+  COMPRESS_VERSION=v1.18.7 \
+  CELGO_VERSION=v0.29.0 \
+  GOPACKET_VERSION=v1.6.1
 
 FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS builder
 
@@ -39,19 +43,23 @@ RUN --mount=type=tmpfs,target=/tmp \
   && touch -d "@$SOURCE_DATE_EPOCH" /tmp/source-date-epoch \
   && mv -T /tmp/source-date-epoch .source-date-epoch
 
-ARG XTEXT_VERSION GRPC_VERSION OTEL_VERSION COMPRESS_VERSION
+ARG XTEXT_VERSION GRPC_VERSION OTEL_VERSION COMPRESS_VERSION CELGO_VERSION GOPACKET_VERSION
 RUN set -eu \
   && go mod edit \
     -require=golang.org/x/text@$XTEXT_VERSION \
     -require=google.golang.org/grpc@$GRPC_VERSION \
     -require=go.opentelemetry.io/otel@$OTEL_VERSION \
     -require=github.com/klauspost/compress@$COMPRESS_VERSION \
+    -require=github.com/google/cel-go@$CELGO_VERSION \
+    -require=github.com/gopacket/gopacket@$GOPACKET_VERSION \
   && go mod tidy \
   && for want in \
     "golang.org/x/text $XTEXT_VERSION" \
     "google.golang.org/grpc $GRPC_VERSION" \
     "go.opentelemetry.io/otel $OTEL_VERSION" \
-    "github.com/klauspost/compress $COMPRESS_VERSION"; \
+    "github.com/klauspost/compress $COMPRESS_VERSION" \
+    "github.com/google/cel-go $CELGO_VERSION" \
+    "github.com/gopacket/gopacket $GOPACKET_VERSION"; \
   do \
     got=$(go list -m "${want% *}"); \
     [ "$got" = "$want" ] || { echo "dependency override lost: got '$got', want '$want'"; exit 1; }; \

--- a/images/calico-node/v3.32.1-3/files/iptables-wrapper.patch
+++ b/images/calico-node/v3.32.1-3/files/iptables-wrapper.patch
@@ -1,0 +1,33 @@
+--- Makefile
++++ Makefile
+@@ -7,7 +7,7 @@ $(BIN_DIR):
+ 	mkdir -p $(BIN_DIR)
+ 
+ build: $(BIN_DIR)
+-	CGO_ENABLED=0 $(GO) build -ldflags='-s -w -extldflags="-static" -buildid=""' -trimpath -o $(BIN_DIR)/iptables-wrapper github.com/kubernetes-sigs/iptables-wrappers
++	CGO_ENABLED=0 $(GO) build -ldflags='-s -w -extldflags="-static" -buildid=""' -trimpath -buildvcs=false -o $(BIN_DIR)/iptables-wrapper github.com/kubernetes-sigs/iptables-wrappers
+ 
+ vet: ## Run go vet against code.
+ 	$(GO) vet ./...
+--- iptables-wrapper-installer.sh
++++ iptables-wrapper-installer.sh
+@@ -85,11 +85,15 @@ done
+ 
+ if [ -z "${no_sanity_check}" ]; then
+     # Ensure dependencies are installed
+-    if ! version=$("${sbin}/iptables-nft" --version 2> /dev/null); then
+-        echo "ERROR: iptables-nft is not installed" 1>&2
+-        exit 1
++    # NOTE(k0s): iptables-nft will fail under QEMU with the below error
++    # message, hence use iptables-legacy for the version check
++    if ! version=$("${sbin}/iptables-nft" --version 2>&1); then
++        if [ "$version" != "iptables: Failed to initialize nft: Protocol not supported" ]; then
++            echo "ERROR: iptables-nft is not installed" 1>&2
++            exit 1
++        fi
+     fi
+-    if ! "${sbin}/iptables-legacy" --version > /dev/null 2>&1; then
++    if ! version=$("${sbin}/iptables-legacy" --version 2> /dev/null); then
+         echo "ERROR: iptables-legacy is not installed" 1>&2
+         exit 1
+     fi


### PR DESCRIPTION
Bump the Go build image to 1.26.6 and add cel-go/gopacket dependency
overrides, since upstream v3.32.1 hasn't picked them up yet. Verified
with trivy: 0 vulnerabilities against the rebuilt image.

Fixes:
- Go stdlib: CVE-2026-39821, CVE-2026-46600, CVE-2026-33818,
  CVE-2026-56853, CVE-2026-56858, CVE-2026-56859, CVE-2026-56860,
  CVE-2026-56862 (golang:1.26.5-alpine3.23 -> golang:1.26.6-alpine3.23,
  affects calico-node, mountns, iptables-wrapper)
- github.com/google/cel-go: GHSA-gcjh-h69q-9w9g (v0.26.0 -> v0.29.0,
  affects calico-node)
- github.com/gopacket/gopacket: CVE-2026-54332, CVE-2026-54345
  (v1.4.0 -> v1.6.1, affects calico-node)
