### PR TITLE
Bump coredns Go and deps to fix CVEs

### DIFF
--- a/images/coredns/1.14.6-k0s.1/Dockerfile
+++ b/images/coredns/1.14.6-k0s.1/Dockerfile
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 k0s authors
+
+ARG BUILDER_IMAGE=docker.io/library/golang:1.26.4-alpine3.24@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648
+
+ARG \
+  VERSION=1.14.6 \
+  GIT_COMMIT=424d125775cd70fa90dfc80bf0e52cc9a9aeb574 \
+  HASH=44af24bd9ab0b9f85a9feaa3132de72e9e4a0629452d41b3e2f49aa2028233af
+
+FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS build-base
+ENV GOTOOLCHAIN=local GOTELEMETRY=off
+WORKDIR /go/src/coredns
+
+
+FROM build-base AS sources
+ARG VERSION HASH
+RUN --mount=type=tmpfs,target=/tmp \
+  set -eu \
+  && wget -qO /tmp/sources.tar.gz https://github.com/coredns/coredns/archive/refs/tags/v$VERSION.tar.gz \
+  && { echo $HASH /tmp/sources.tar.gz | sha256sum -c -; } || { sha256sum /tmp/sources.tar.gz; exit 1; } \
+  && tar xf /tmp/sources.tar.gz --strip-components=1
+RUN go mod download
+
+
+FROM build-base AS build
+RUN apk add --no-cache libcap-setcap
+ARG TARGETARCH GIT_COMMIT
+RUN --mount=from=sources,source=/go/src/coredns,target=/go/src/coredns,ro \
+  --mount=from=sources,source=/go/pkg/mod,target=/go/pkg/mod,ro \
+  --mount=type=cache,id=coredns-go-cache-$TARGETARCH,target=/root/.cache/go-build \
+  --mount=type=tmpfs,target=/tmp \
+  --network=none \
+  CGO_ENABLED=0 \
+  GOARCH=$TARGETARCH \
+  go build -mod=readonly -trimpath -buildvcs=false \
+    -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$GIT_COMMIT" \
+    -o /coredns \
+  && setcap cap_net_bind_service=+ep /coredns
+
+
+FROM build-base AS baselayout
+ARG SOURCE_DATE_EPOCH
+RUN apk add --no-cache ca-certificates-bundle
+
+
+FROM scratch
+LABEL org.opencontainers.image.licenses="Apache-2.0" \
+  org.opencontainers.image.source="https://github.com/coredns/coredns"
+ARG VERSION
+
+COPY --from=baselayout /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /coredns /coredns
+USER 65532:65532
+
+EXPOSE 53 53/udp
+ENTRYPOINT ["/coredns"]

--- a/images/coredns/1.14.6-k0s.1/Dockerfile
+++ b/images/coredns/1.14.6-k0s.1/Dockerfile
@@ -1,12 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 k0s authors
 
-ARG BUILDER_IMAGE=docker.io/library/golang:1.26.4-alpine3.24@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648
+ARG BUILDER_IMAGE=docker.io/library/golang:1.26.6-alpine3.24@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df
 
 ARG \
   VERSION=1.14.6 \
   GIT_COMMIT=424d125775cd70fa90dfc80bf0e52cc9a9aeb574 \
   HASH=44af24bd9ab0b9f85a9feaa3132de72e9e4a0629452d41b3e2f49aa2028233af
+
+# Dependency overrides for advisories still open in coredns v1.14.6:
+# CVE-2026-56864/CVE-2026-56865 (x/mod) and GHSA-hrxh-6v49-42gf (grpc).
+# Raising them requires `go mod tidy`, which also nudges a handful of
+# unrelated transitive dependencies, so drop each override again once
+# upstream picks the version up. x/mod's own requirements pull x/text
+# up transitively, which also clears CVE-2026-56852 (x/text) without
+# needing a direct override.
+ARG \
+  XMOD_VERSION=v0.40.0 \
+  GRPC_VERSION=v1.82.1
 
 FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS build-base
 ENV GOTOOLCHAIN=local GOTELEMETRY=off
@@ -20,7 +31,21 @@ RUN --mount=type=tmpfs,target=/tmp \
   && wget -qO /tmp/sources.tar.gz https://github.com/coredns/coredns/archive/refs/tags/v$VERSION.tar.gz \
   && { echo $HASH /tmp/sources.tar.gz | sha256sum -c -; } || { sha256sum /tmp/sources.tar.gz; exit 1; } \
   && tar xf /tmp/sources.tar.gz --strip-components=1
-RUN go mod download
+
+ARG XMOD_VERSION GRPC_VERSION
+RUN set -eu \
+  && go mod edit \
+    -require=golang.org/x/mod@$XMOD_VERSION \
+    -require=google.golang.org/grpc@$GRPC_VERSION \
+  && go mod tidy \
+  && for want in \
+    "golang.org/x/mod $XMOD_VERSION" \
+    "google.golang.org/grpc $GRPC_VERSION"; \
+  do \
+    got=$(go list -m "${want% *}"); \
+    [ "$got" = "$want" ] || { echo "dependency override lost: got '$got', want '$want'"; exit 1; }; \
+  done \
+  && go mod download
 
 
 FROM build-base AS build


### PR DESCRIPTION
Bump the Go build image to 1.26.6 and add dependency overrides for
x/mod and grpc, since upstream v1.14.6 hasn't picked them up yet.
Verified with trivy: 0 vulnerabilities against the rebuilt image.

Fixes:
- Go stdlib: CVE-2026-39821, CVE-2026-39822, CVE-2026-46600,
  CVE-2026-42505, CVE-2026-33818, CVE-2026-56853, CVE-2026-56858,
  CVE-2026-56859, CVE-2026-56860, CVE-2026-56862
  (golang:1.26.4-alpine3.24 -> golang:1.26.6-alpine3.24)
- golang.org/x/mod: CVE-2026-56864, CVE-2026-56865 (v0.36.0 -> v0.40.0)
- google.golang.org/grpc: GHSA-hrxh-6v49-42gf (v1.82.0 -> v1.82.1)
- golang.org/x/text: CVE-2026-56852 (v0.38.0 -> v0.41.0, pulled up
  transitively by the x/mod bump, no direct override needed)
