### PR TITLE
Bump kube-router Go and deps to fix CVEs

### DIFF
--- a/images/kube-router/v2.10.0-iptables1.8.13-k0s.2/Dockerfile
+++ b/images/kube-router/v2.10.0-iptables1.8.13-k0s.2/Dockerfile
@@ -3,13 +3,23 @@ ARG \
   # https://github.com/cloudnativelabs/kube-router/blob/v2.10.0/Makefile#L40 (v4.5.0)
   GOBGP_REVISION=5f191066a78e2c1e929c54b5b75fe2c683c166e4 \
   ALPINE_IMAGE=docker.io/library/alpine:3.24.1 \
-  BUILDER_IMAGE=docker.io/library/golang:1.26.5-alpine3.24 \
+  BUILDER_IMAGE=docker.io/library/golang:1.26.6-alpine3.24 \
   IPTABLES_VERSION=1.8.13 \
   IPTABLES_HASH=1afcd33da9e8f913ace6a2126788162e207e26f5d5e29c6573c0e581ffc58b99 \
   IPTABLES_WRAPPER_VERSION=06cad2ec6cb5ed0945b383fb185424c0a67f55eb \
   IPTABLES_WRAPPER_HASH=fde9ccd22b337fd297180cd21938c0a82030187fc29aabb6800472295d62752a \
   IPSET_VERSION=7.24 \
   IPSET_HASH=fbe3424dff222c1cb5e5c34d38b64524b2217ce80226c14fdcbb13b29ea36112
+
+# Dependency overrides for advisories still open upstream:
+# GHSA-hrxh-6v49-42gf (grpc, both gobgp and kube-router) and
+# CVE-2026-49837/CVE-2026-49838 (github.com/osrg/gobgp/v4, the library
+# kube-router imports - distinct from the standalone gobgp binary built
+# from GOBGP_REVISION above). Drop each override again once upstream
+# picks the version up.
+ARG \
+  GRPC_VERSION=v1.82.1 \
+  GOBGP_LIB_VERSION=v4.7.0
 
 FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS build-base
 RUN apk add --no-interactive --no-cache git make
@@ -21,7 +31,9 @@ FROM build-base AS build-gobgp
 ARG GOBGP_REVISION
 WORKDIR /go/src/gobgp
 RUN git -C .. -c advice.detachedHead=false clone --revision "$GOBGP_REVISION" https://github.com/osrg/gobgp.git
+ARG GRPC_VERSION
 RUN go mod edit -replace golang.org/x/net=golang.org/x/net@v0.57.0 \
+  -require=google.golang.org/grpc@$GRPC_VERSION \
   && go mod tidy \
   && go mod download
 
@@ -36,7 +48,10 @@ FROM build-base AS build-kube-router
 ARG KUBE_ROUTER_VERSION
 WORKDIR /go/src/kube-router
 RUN git -C .. -c advice.detachedHead=false clone --branch $KUBE_ROUTER_VERSION https://github.com/cloudnativelabs/kube-router.git
+ARG GRPC_VERSION GOBGP_LIB_VERSION
 RUN go mod edit -replace golang.org/x/net=golang.org/x/net@v0.57.0 \
+  -require=google.golang.org/grpc@$GRPC_VERSION \
+  -require=github.com/osrg/gobgp/v4@$GOBGP_LIB_VERSION \
   && go mod tidy \
   && go mod download
 

--- a/images/kube-router/v2.10.0-iptables1.8.13-k0s.2/Dockerfile
+++ b/images/kube-router/v2.10.0-iptables1.8.13-k0s.2/Dockerfile
@@ -1,0 +1,154 @@
+ARG \
+  KUBE_ROUTER_VERSION=v2.10.0 \
+  # https://github.com/cloudnativelabs/kube-router/blob/v2.10.0/Makefile#L40 (v4.5.0)
+  GOBGP_REVISION=5f191066a78e2c1e929c54b5b75fe2c683c166e4 \
+  ALPINE_IMAGE=docker.io/library/alpine:3.24.1 \
+  BUILDER_IMAGE=docker.io/library/golang:1.26.5-alpine3.24 \
+  IPTABLES_VERSION=1.8.13 \
+  IPTABLES_HASH=1afcd33da9e8f913ace6a2126788162e207e26f5d5e29c6573c0e581ffc58b99 \
+  IPTABLES_WRAPPER_VERSION=06cad2ec6cb5ed0945b383fb185424c0a67f55eb \
+  IPTABLES_WRAPPER_HASH=fde9ccd22b337fd297180cd21938c0a82030187fc29aabb6800472295d62752a \
+  IPSET_VERSION=7.24 \
+  IPSET_HASH=fbe3424dff222c1cb5e5c34d38b64524b2217ce80226c14fdcbb13b29ea36112
+
+FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS build-base
+RUN apk add --no-interactive --no-cache git make
+ENV GOTOOLCHAIN=local
+
+
+FROM build-base AS build-gobgp
+
+ARG GOBGP_REVISION
+WORKDIR /go/src/gobgp
+RUN git -C .. -c advice.detachedHead=false clone --revision "$GOBGP_REVISION" https://github.com/osrg/gobgp.git
+RUN go mod edit -replace golang.org/x/net=golang.org/x/net@v0.57.0 \
+  && go mod tidy \
+  && go mod download
+
+ARG TARGETARCH
+RUN --mount=type=cache,id=kube-router-gocache-$TARGETARCH,target=/root/.cache/go-build \
+  --network=none \
+  GOARCH="$TARGETARCH" CGO_ENABLED=0 go build -mod=readonly -trimpath -buildvcs=false -ldflags "-s -w" ./cmd/gobgp
+
+
+FROM build-base AS build-kube-router
+
+ARG KUBE_ROUTER_VERSION
+WORKDIR /go/src/kube-router
+RUN git -C .. -c advice.detachedHead=false clone --branch $KUBE_ROUTER_VERSION https://github.com/cloudnativelabs/kube-router.git
+RUN go mod edit -replace golang.org/x/net=golang.org/x/net@v0.57.0 \
+  && go mod tidy \
+  && go mod download
+
+ARG TARGETARCH
+RUN --mount=type=cache,id=kube-router-gocache-$TARGETARCH,target=/root/.cache/go-build \
+  --network=none \
+  export GIT_COMMIT=$(git describe --tags --dirty) \
+  && export BUILD_DATE=$(git log -1 --date=format:%Y-%m-%dT%H:%M:%S%z --format=%cd) \
+  && GOARCH="$TARGETARCH" CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/cloudnativelabs/kube-router/v2/pkg/version.Version=$GIT_COMMIT -X github.com/cloudnativelabs/kube-router/v2/pkg/version.BuildDate=$BUILD_DATE" \
+    -trimpath -buildvcs=false ./cmd/kube-router
+
+
+FROM build-base AS build-iptables-wrapper
+
+ARG IPTABLES_WRAPPER_VERSION IPTABLES_WRAPPER_HASH
+WORKDIR /go/src/iptables-wrapper
+RUN --mount=type=tmpfs,target=/tmp \
+  set -euo pipefail \
+  && wget -qO /tmp/sources.tar.gz "https://github.com/kubernetes-sigs/iptables-wrappers/archive/$IPTABLES_WRAPPER_VERSION.tar.gz" \
+  && { echo $IPTABLES_WRAPPER_HASH /tmp/sources.tar.gz | sha256sum -c -; } \
+  && mkdir -p /go/iptables-wrapper \
+  && tar xf /tmp/sources.tar.gz --strip-components=1
+
+ARG TARGETARCH
+RUN --mount=type=tmpfs,target=/go/src/iptables-wrapper/bin \
+  --mount=type=cache,id=kube-router-gocache-$TARGETARCH,target=/root/.cache/go-build \
+  --network=none \
+  du -sh /root/.cache/go-build \
+  && GOARCH="$TARGETARCH" make build \
+  && mv bin/iptables-wrapper .
+
+
+FROM $ALPINE_IMAGE AS build-iptables
+
+RUN apk add --no-interactive --no-cache \
+  build-base curl pkgconf \
+  linux-headers \
+  libmnl-dev libmnl-static \
+  libnftnl-dev
+
+ARG IPTABLES_VERSION IPTABLES_HASH
+WORKDIR /src/iptables
+RUN --mount=type=tmpfs,target=/tmp \
+  wget -qO /tmp/sources.tar.gz https://www.netfilter.org/projects/iptables/files/iptables-$IPTABLES_VERSION.tar.xz \
+  && { echo $IPTABLES_HASH /tmp/sources.tar.gz | sha256sum -c -; } \
+  && tar xf /tmp/sources.tar.gz --strip-components=1
+
+# -D__UAPI_DEF_ETHHDR is required to build on musl.
+# If this CFLAG isn't defined, itpables will define it in include/xtables.h
+# and will have a conflict with musl, which defines it in
+# /usr/include/netinet/if_ether.h
+RUN --network=none \
+  CFLAGS="-Os -D__UAPI_DEF_ETHHDR=0" ./configure --sysconfdir=/etc --enable-static --disable-shared --without-kernel --disable-devel
+
+RUN --network=none \
+  make -j$(nproc) LDFLAGS=-all-static
+RUN --network=none \
+  make -j$(nproc) install \
+  && strip /usr/local/sbin/xtables-*
+
+
+FROM $ALPINE_IMAGE AS build-ipset
+RUN apk add --no-interactive --no-cache \
+  build-base pkgconf \
+  libmnl-dev libmnl-static
+
+
+ARG IPSET_VERSION IPSET_HASH
+WORKDIR /src/ipset
+RUN --mount=type=tmpfs,target=/tmp \
+  wget -qO /tmp/sources.tar.gz https://ipset.netfilter.org/ipset-$IPSET_VERSION.tar.bz2 \
+  && { echo $IPSET_HASH /tmp/sources.tar.gz | sha256sum -c -; } \
+  && tar xf /tmp/sources.tar.gz --strip-components=1
+
+RUN --network=none \
+  printf '#!/usr/bin/env sh\nexec cc -static "$@"\n' >/src/cc-static && chmod +x /src/cc-static \
+  && CC=/src/cc-static CFLAGS=-static LDFLAGS=-static ./configure --enable-static --disable-shared --with-kmod=no \
+  && make \
+  && strip src/ipset \
+  && make install
+# Just a sanity check that it's not segfaulting
+RUN ipset -h
+
+
+FROM $ALPINE_IMAGE
+LABEL org.opencontainers.image.licenses="Apache-2.0" \
+  org.opencontainers.image.source="https://github.com/cloudnativelabs/kube-router"
+RUN apk add --no-interactive --no-cache \
+  iproute2 \
+  ipvsadm \
+  conntrack-tools \
+  curl \
+  bash \
+  && mkdir -p /var/lib/gobgp
+RUN --mount=from=build-iptables,source=/usr/local,target=/run/stage/iptables,ro \
+  --mount=from=build-iptables-wrapper,source=/go/src/iptables-wrapper,target=/run/stage/iptables-wrapper,ro \
+  --network=none \
+  cp -a /run/stage/iptables/sbin/xtables-* /run/stage/iptables/sbin/iptables* /run/stage/iptables/sbin/ip6tables* /sbin/ \
+  && (cd /run/stage/iptables-wrapper && ./iptables-wrapper-installer.sh --no-sanity-check --no-cleanup)
+
+RUN --mount=from=build-ipset,source=/,target=/run/stage/ipset,ro \
+  --network=none \
+  cp -a /run/stage/ipset/usr/local/sbin/ipset /usr/sbin/ipset \
+  && mkdir -p /usr/share/doc/ipset \
+  && cp -a /run/stage/ipset/src/ipset/ChangeLog /usr/share/doc/ipset/ChangeLog
+
+COPY --from=build-gobgp /go/src/gobgp/gobgp /usr/local/bin/
+RUN --mount=from=build-kube-router,source=/go/src/kube-router,target=/run/stage/kube-router,ro \
+  --network=none \
+  cp -a /run/stage/kube-router/kube-router /usr/local/bin/ \
+  && cp -a /run/stage/kube-router/build/image-assets/motd-kube-router.sh /etc/ \
+  && echo "hosts: files dns" >/etc/nsswitch.conf
+
+WORKDIR /root
+ENTRYPOINT ["/usr/local/bin/kube-router"]


### PR DESCRIPTION
Bump the Go build image to 1.26.6 and add dependency overrides for
grpc (both gobgp and kube-router builds) and the gobgp/v4 library
kube-router imports, since upstream v2.10.0 hasn't picked them up yet.
Verified with trivy: 0 vulnerabilities against the rebuilt image.

Fixes:
- Go stdlib: CVE-2026-39821, CVE-2026-46600, CVE-2026-33818,
  CVE-2026-56853, CVE-2026-56858, CVE-2026-56859, CVE-2026-56860,
  CVE-2026-56862 (golang:1.26.5-alpine3.24 -> golang:1.26.6-alpine3.24,
  affects iptables-wrapper, gobgp, kube-router)
- google.golang.org/grpc: GHSA-hrxh-6v49-42gf (gobgp v1.79.3 -> v1.82.1,
  kube-router v1.81.1 -> v1.82.1)
- github.com/osrg/gobgp/v4 (library import in kube-router, distinct
  from the standalone gobgp binary): CVE-2026-49837, CVE-2026-49838
  (v4.5.0 -> v4.7.0)
